### PR TITLE
Adds some code to support VO and domain models

### DIFF
--- a/src/Bridge/Symfony/Form/Type/ApiType.php
+++ b/src/Bridge/Symfony/Form/Type/ApiType.php
@@ -3,12 +3,60 @@
 namespace Biig\Melodiia\Bridge\Symfony\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class ApiType extends AbstractType
 {
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefaults(['csrf_protection' => false]);
+        $resolver->setDefaults([
+            'csrf_protection' => false,
+
+            /*
+             * Creates data object just like standard form would do
+             * but used constructor with given data.
+             *
+             * @param FormInterface $form
+             * @return null|object
+             * @throws \ReflectionException
+             */
+            'empty_data' => function (FormInterface $form) {
+                $dataClass = $form->getConfig()->getOption('data_class');
+
+                if (!class_exists($dataClass)) {
+                    return null;
+                }
+
+                $ref = new \ReflectionClass($dataClass);
+                $constructorParameters = $ref->getConstructor()->getParameters();
+
+                // Case of anemic model, we have nothing to do here.
+                if (count($constructorParameters) < 1) {
+                    return new $dataClass();
+                }
+
+                $constructorData = [];
+                foreach ($constructorParameters as $parameter) {
+                    if ($form->has($parameter->getName())) {
+                        if (null === $form->get($parameter->getName())->getData() && !$parameter->allowsNull() && !$parameter->isDefaultValueAvailable()) {
+                            return null;
+                        }
+
+                        $data = $form->get($parameter->getName())->getData();
+                    } else {
+                        $data = null;
+                    }
+
+                    if (empty($data) && $parameter->isDefaultValueAvailable()) {
+                        $data = $parameter->getDefaultValue();
+                    }
+
+                    $constructorData[] = $data;
+                }
+
+                return new $dataClass(...$constructorData);
+            },
+        ]);
     }
 }

--- a/tests/Melodiia/Bridge/Doctrine/DoctrineDataStoreTest.php
+++ b/tests/Melodiia/Bridge/Doctrine/DoctrineDataStoreTest.php
@@ -1,7 +1,8 @@
 <?php
 
-namespace Biig\Melodiia\Bridge\Doctrine;
+namespace Biig\Melodiia\Test\Bridge\Doctrine;
 
+use Biig\Melodiia\Bridge\Doctrine\DoctrineDataStore;
 use Biig\Melodiia\Crud\Persistence\DataStoreInterface;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\TestCase;

--- a/tests/Melodiia/Bridge/Symfony/Form/ApiTypeTest.php
+++ b/tests/Melodiia/Bridge/Symfony/Form/ApiTypeTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Biig\Melodiia\Test\Bridge\Symfony\Form;
+
+use Biig\Melodiia\Bridge\Symfony\Form\Type\ApiType;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormView;
+use Symfony\Component\Form\Test\FormIntegrationTestCase;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class ApiTypeTest extends FormIntegrationTestCase
+{
+    public function testItIsASymfonyFormType()
+    {
+        $type = new ApiType();
+
+        $this->assertInstanceOf(AbstractType::class, $type);
+    }
+
+    public function testItReturnsNullForEmptyDataInCaseOfNoDataAvailable()
+    {
+        $form = $this->factory->createNamed('', FakeTypeUsingApiType::class);
+        $this->assertEquals(null, $form->getData());
+        $this->assertInstanceOf(FormView::class, $form->createView());
+    }
+
+    public function testItReturnsDataForEmptyDataInCaseOfDataAvailable()
+    {
+        $form = $this->factory->createNamed('', FakeTypeUsingApiType::class);
+        $form->submit(['foo' => 'some content']);
+        $data = $form->getData();
+        $this->assertInstanceOf(FakeModel::class, $data);
+        $this->assertEquals('some content', $data->getFoo());
+    }
+
+    protected function getTypes()
+    {
+        return [new ApiType];
+    }
+}
+
+class FakeModel {
+    private $foo;
+    public function __construct(string $foo)
+    {
+        $this->foo = $foo;
+    }
+
+    public function getFoo()
+    {
+        return $this->foo;
+    }
+}
+
+class FakeTypeUsingApiType extends \Biig\Melodiia\Bridge\Symfony\Form\AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder->add('foo');
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults(['data_class' => FakeModel::class]);
+    }
+}


### PR DESCRIPTION
By default Sf forms are not supporting VO / Domain models.

This methods default configuration adds support for Value Objects
and Domain Models.

Here comes also a little fix for test suite.