### PR TITLE
Add GET controller for CRUD

### DIFF
--- a/src/Bridge/Doctrine/DoctrineDataStore.php
+++ b/src/Bridge/Doctrine/DoctrineDataStore.php
@@ -20,4 +20,9 @@ class DoctrineDataStore implements DataStoreInterface
         $this->entityManager->persist($model);
         $this->entityManager->flush($model);
     }
+
+    public function find(string $type, $id): ?object
+    {
+        return $this->entityManager->getRepository($type)->find($id);
+    }
 }

--- a/src/Bridge/Symfony/Resources/config/crud.yaml
+++ b/src/Bridge/Symfony/Resources/config/crud.yaml
@@ -11,3 +11,9 @@ services:
             $formFactory: '@form.factory'
             $dispatcher: '@event_dispatcher'
         tags: [ controller.service_arguments ]
+
+    melodiia.crud.controller.get:
+        class: Biig\Melodiia\Crud\Controller\Get
+        arguments:
+            $dataStore: '@melodiia.doctrine.data_provider'
+        tags: [ controller.service_arguments ]

--- a/src/Bridge/Symfony/Resources/config/services.yaml
+++ b/src/Bridge/Symfony/Resources/config/services.yaml
@@ -21,6 +21,12 @@ services:
         class: Biig\Melodiia\Serialization\Json\ErrorNormalizer
         tags: [{ name: 'serializer.normalizer', priority: -1 }]
 
+    melodiia.serialization.ok_content_normalizer:
+        class: Biig\Melodiia\Serialization\Json\OkContentNormalizer
+        arguments:
+            $normalizer: '@serializer.normalizer.object'
+        tags: [{ name: 'serializer.normalizer', priority: -1 }]
+
     Biig\Melodiia\MelodiiaConfigurationInterface: '@melodiia.configuration'
 
     melodiia.response_listener:

--- a/src/Crud/Controller/Create.php
+++ b/src/Crud/Controller/Create.php
@@ -4,10 +4,12 @@ namespace Biig\Melodiia\Crud\Controller;
 
 use Biig\Melodiia\Bridge\Symfony\Response\FormErrorResponse;
 use Biig\Melodiia\Crud\CrudableModelInterface;
+use Biig\Melodiia\Crud\CrudControllerInterface;
 use Biig\Melodiia\Crud\Event\CrudEvent;
 use Biig\Melodiia\Crud\Event\CustomResponseEvent;
 use Biig\Melodiia\Crud\Persistence\DataStoreInterface;
 use Biig\Melodiia\Exception\MelodiiaLogicException;
+use Biig\Melodiia\Response\ApiResponse;
 use Biig\Melodiia\Response\Created;
 use Biig\Melodiia\Response\WrongDataInput;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -18,7 +20,7 @@ use Zend\Json\Json;
 /**
  * Crud controller that create data model with the data from the request using a form.
  */
-final class Create
+final class Create implements CrudControllerInterface
 {
     public const EVENT_PRE_CREATE = 'melodiia.crud.pre_create';
     public const EVENT_POST_CREATE = 'melodiia.crud.post_create';
@@ -39,11 +41,11 @@ final class Create
         $this->dispatcher = $dispatcher;
     }
 
-    public function __invoke(Request $request)
+    public function __invoke(Request $request): ApiResponse
     {
         // Metadata you can specify in routing definition
-        $modelClass = $request->attributes->get('melodiia_model');
-        $form = $request->attributes->get('melodiia_form');
+        $modelClass = $request->attributes->get(self::MODEL_ATTRIBUTE);
+        $form = $request->attributes->get(self::FORM_ATTRIBUTE);
 
         if (empty($modelClass) || !class_exists($modelClass) || !is_subclass_of($modelClass, CrudableModelInterface::class)) {
             throw new MelodiiaLogicException('If you use melodiia CRUD classes, you need to specify a model.');

--- a/src/Crud/Controller/Get.php
+++ b/src/Crud/Controller/Get.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Biig\Melodiia\Crud\Controller;
+
+use Biig\Melodiia\Crud\CrudControllerInterface;
+use Biig\Melodiia\Crud\Persistence\DataStoreInterface;
+use Biig\Melodiia\Response\ApiResponse;
+use Biig\Melodiia\Response\NotFound;
+use Biig\Melodiia\Response\OkContent;
+use Symfony\Component\HttpFoundation\Request;
+
+final class Get implements CrudControllerInterface
+{
+    /** @var DataStoreInterface */
+    private $dataStore;
+
+    public function __construct(DataStoreInterface $dataStore)
+    {
+        $this->dataStore = $dataStore;
+    }
+
+    public function __invoke(Request $request, $id): ApiResponse
+    {
+        $modelClass = $request->attributes->get(self::MODEL_ATTRIBUTE);
+        $groups = $request->attributes->get(self::SERIALIZATION_GROUP, []);
+
+        $data = $this->dataStore->find($modelClass, $id);
+
+        if (null === $data) {
+            return new NotFound();
+        }
+
+        return new OkContent($data, $groups);
+    }
+}

--- a/src/Crud/CrudControllerInterface.php
+++ b/src/Crud/CrudControllerInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Biig\Melodiia\Crud;
+
+interface CrudControllerInterface
+{
+    public const MODEL_ATTRIBUTE = 'melodiia_model';
+    public const FORM_ATTRIBUTE = 'melodiia_form';
+    public const SERIALIZATION_GROUP = 'melodiia_serialization_group';
+}

--- a/src/Crud/Persistence/DataStoreInterface.php
+++ b/src/Crud/Persistence/DataStoreInterface.php
@@ -5,4 +5,6 @@ namespace Biig\Melodiia\Crud\Persistence;
 interface DataStoreInterface
 {
     public function save(object $model);
+
+    public function find(string $type, $id): ?object;
 }

--- a/src/Response/Model/SerializationContext.php
+++ b/src/Response/Model/SerializationContext.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Biig\Melodiia\Response\Model;
+
+class SerializationContext
+{
+    /** @var array */
+    private $groups;
+
+    /**
+     * @param string|array $groups
+     */
+    public function __construct($groups)
+    {
+        $this->groups = [];
+        $this->addGroups($groups);
+    }
+
+    /**
+     * @param array|string $groups
+     */
+    public function addGroups($groups): void
+    {
+        $groups = (array) $groups;
+        foreach ($groups as $group) {
+            $this->groups[] = $group;
+        }
+    }
+
+    public function getGroups(): array
+    {
+        return $this->groups;
+    }
+}

--- a/src/Response/NotFound.php
+++ b/src/Response/NotFound.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Biig\Melodiia\Response;
+
+class NotFound extends AbstractApiResponse
+{
+    public function __construct(string $message = 'Resource not found')
+    {
+        parent::__construct($message);
+    }
+
+    public function httpStatus(): int
+    {
+        return 404;
+    }
+}

--- a/src/Response/OkContent.php
+++ b/src/Response/OkContent.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Biig\Melodiia\Response;
+
+use Biig\Melodiia\Response\Model\SerializationContext;
+
+class OkContent implements ApiResponse, SerializationContextAwareInterface
+{
+    use SerializationContextAwareTrait;
+
+    /** @var mixed */
+    private $content;
+
+    public function __construct($content, $serializationGroups = [])
+    {
+        $this->content = $content;
+        $this->serializationContext = new SerializationContext($serializationGroups);
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getContent()
+    {
+        return $this->content;
+    }
+
+    public function httpStatus(): int
+    {
+        return 200;
+    }
+}

--- a/src/Response/SerializationContextAwareInterface.php
+++ b/src/Response/SerializationContextAwareInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Biig\Melodiia\Response;
+
+use Biig\Melodiia\Response\Model\SerializationContext;
+
+interface SerializationContextAwareInterface
+{
+    public function getSerializationContext(): SerializationContext;
+
+    public function setSerializationContext(SerializationContext $context);
+}

--- a/src/Response/SerializationContextAwareTrait.php
+++ b/src/Response/SerializationContextAwareTrait.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Biig\Melodiia\Response;
+
+use Biig\Melodiia\Response\Model\SerializationContext;
+
+trait SerializationContextAwareTrait
+{
+    /** @var SerializationContext */
+    private $serializationContext;
+
+    public function getSerializationContext(): SerializationContext
+    {
+        return $this->serializationContext;
+    }
+
+    public function setSerializationContext(SerializationContext $context)
+    {
+        $this->serializationContext = $context;
+    }
+}

--- a/src/Serialization/Json/OkContentNormalizer.php
+++ b/src/Serialization/Json/OkContentNormalizer.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Biig\Melodiia\Serialization\Json;
+
+use Biig\Melodiia\Response\OkContent;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/**
+ * Class OkContentNormalizer.
+ *
+ * Normalize only the content of OkContent object using the serialization
+ * context contained in OkContent object.
+ */
+class OkContentNormalizer implements NormalizerInterface
+{
+    /** @var NormalizerInterface */
+    private $decorated;
+
+    public function __construct(NormalizerInterface $normalizer)
+    {
+        $this->decorated = $normalizer;
+    }
+
+    /**
+     * @param OkContent $object
+     * @param string    $format
+     * @param array     $context
+     *
+     * @return array|bool|float|int|string|void
+     */
+    public function normalize($object, $format = null, array $context = array())
+    {
+        $groups = $object->getSerializationContext()->getGroups();
+        if (!empty($context['groups'])) {
+            $groups = array_merge($context['groups'], $groups);
+        }
+
+        $context['groups'] = $groups;
+
+        return $this->decorated->normalize($object->getContent(), $format, $context);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsNormalization($data, $format = null)
+    {
+        return is_object($data) && $data instanceof OkContent;
+    }
+}

--- a/tests/Melodiia/Bridge/Symfony/Form/ApiTypeTest.php
+++ b/tests/Melodiia/Bridge/Symfony/Form/ApiTypeTest.php
@@ -36,12 +36,14 @@ class ApiTypeTest extends FormIntegrationTestCase
 
     protected function getTypes()
     {
-        return [new ApiType];
+        return [new ApiType()];
     }
 }
 
-class FakeModel {
+class FakeModel
+{
     private $foo;
+
     public function __construct(string $foo)
     {
         $this->foo = $foo;

--- a/tests/Melodiia/Crud/Controller/GetTest.php
+++ b/tests/Melodiia/Crud/Controller/GetTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Biig\Melodiia\Test\Crud\Controller;
+
+use Biig\Melodiia\Crud\Controller\Get;
+use Biig\Melodiia\Crud\CrudControllerInterface;
+use Biig\Melodiia\Crud\Persistence\DataStoreInterface;
+use Biig\Melodiia\Response\NotFound;
+use Biig\Melodiia\Response\OkContent;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Prophecy\ObjectProphecy;
+use Symfony\Component\HttpFoundation\ParameterBag;
+use Symfony\Component\HttpFoundation\Request;
+
+class GetTest extends TestCase
+{
+    /** @var DataStoreInterface|ObjectProphecy */
+    private $dataStore;
+
+    /** @var Get */
+    private $controller;
+
+    public function setUp()
+    {
+        $this->dataStore = $this->prophesize(DataStoreInterface::class);
+        $this->controller = new Get($this->dataStore->reveal());
+    }
+
+    public function testItIsIntanceOfMelodiiaController()
+    {
+        $this->assertInstanceOf(CrudControllerInterface::class, $this->controller);
+    }
+
+    public function testItReturnResourceFromDataStoreInsideOkContent()
+    {
+        $this->dataStore->find('foo', 'id')->willReturn(new \stdClass())->shouldBeCalled();
+        $request = $this->prophesize(Request::class);
+        $attributes = $this->prophesize(ParameterBag::class);
+        $attributes->get(CrudControllerInterface::MODEL_ATTRIBUTE)->willReturn('foo');
+        $attributes->get(CrudControllerInterface::SERIALIZATION_GROUP, [])->willReturn([]);
+        $request->attributes = $attributes->reveal();
+
+        $res = ($this->controller)($request->reveal(), 'id');
+
+        $this->assertInstanceOf(OkContent::class, $res);
+        $this->assertInstanceOf(\stdClass::class, $res->getContent());
+    }
+
+    public function testItReturnNotFoundResponseInCaseOfNoResultFromDataStore()
+    {
+        $this->dataStore->find('foo', 'id')->willReturn(null)->shouldBeCalled();
+        $request = $this->prophesize(Request::class);
+        $attributes = $this->prophesize(ParameterBag::class);
+        $attributes->get(CrudControllerInterface::MODEL_ATTRIBUTE)->willReturn('foo');
+        $attributes->get(CrudControllerInterface::SERIALIZATION_GROUP, [])->willReturn([]);
+        $request->attributes = $attributes->reveal();
+
+        $res = ($this->controller)($request->reveal(), 'id');
+
+        $this->assertInstanceOf(NotFound::class, $res);
+    }
+}

--- a/tests/Melodiia/Serialization/Json/OkContentNormalizerTest.php
+++ b/tests/Melodiia/Serialization/Json/OkContentNormalizerTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Biig\Melodiia\Test\Serialization\Json;
+
+use Biig\Melodiia\Response\OkContent;
+use Biig\Melodiia\Serialization\Json\OkContentNormalizer;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+class OkContentNormalizerTest extends TestCase
+{
+    /** @var NormalizerInterface|ObjectProphecy */
+    private $mainNormalizer;
+
+    /** @var OkContentNormalizer */
+    private $okContentNormalizer;
+
+    public function setUp()
+    {
+        $this->mainNormalizer = $this->prophesize(NormalizerInterface::class);
+
+        $this->okContentNormalizer = new OkContentNormalizer($this->mainNormalizer->reveal());
+    }
+
+    public function testItIsInstanceOfNormalizerInterface()
+    {
+        $this->assertInstanceOf(NormalizerInterface::class, $this->okContentNormalizer);
+    }
+
+    public function testItReturnsDirectlyTheNormalizationOfContainedItem()
+    {
+        $okContent = new OkContent('foo');
+
+        $this->mainNormalizer->normalize('foo', Argument::cetera())->willReturn('foo normalized')->shouldBeCalled();
+
+        $res = $this->okContentNormalizer->normalize($okContent);
+
+        $this->assertEquals('foo normalized', $res);
+    }
+
+    public function testItSupportsOnlyOkContentInstance()
+    {
+        $this->assertTrue($this->okContentNormalizer->supportsNormalization(new OkContent('foo')));
+        $this->assertFalse($this->okContentNormalizer->supportsNormalization(new \stdClass()));
+        $this->assertFalse($this->okContentNormalizer->supportsNormalization('foo'));
+    }
+
+    public function testItAddsGroupsToNormalizationContext()
+    {
+        $okContent = new OkContent('foo', ['foo-group']);
+
+        $this->mainNormalizer->normalize('foo', Argument::any(), ['groups' => ['foo-group']])->willReturn('foo normalized')->shouldBeCalled();
+
+        $res = $this->okContentNormalizer->normalize($okContent);
+
+        $this->assertEquals('foo normalized', $res);
+    }
+}


### PR DESCRIPTION
This commit also adds a new `OkContent` response that can handle a content. This response will be ignore on serialization and only the content will be the result of the serialization thanks to the `OkContentNormalizer`.

For obvious customization need, it also comes with a new feature: serialization context, which only support groups for the moment but is extensible.