### PR TITLE
Add set of classes for CRUD documentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: php
+php:
+    - 7.2
+    - 7.3
+
+branches:
+    only:
+        - master
+
+install:
+    - composer install
+
+script:
+    - ./vendor/bin/phpunit -c phpunit.xml.dist

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
         "phpspec/prophecy": "^1.8",
         "twig/twig": "^2.5",
         "symfony/symfony": "^4.2",
-        "doctrine/orm": "^2.6"
+        "doctrine/orm": "^2.6",
+        "justinrainbow/json-schema": "^5.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Bridge/Symfony/Routing/CrudDocumentationFactory.php
+++ b/src/Bridge/Symfony/Routing/CrudDocumentationFactory.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace Biig\Melodiia\Bridge\Symfony\Routing;
+
+use Biig\Melodiia\Crud\CrudControllerInterface;
+use Biig\Melodiia\Documentation\DocumentationFactoryInterface;
+use Nekland\Tools\StringTools;
+use OpenApi\Analysis;
+use OpenApi\Annotations\Get;
+use OpenApi\Annotations\JsonContent;
+use OpenApi\Annotations\MediaType;
+use OpenApi\Annotations\Parameter;
+use OpenApi\Annotations\Post;
+use OpenApi\Annotations\Response;
+use OpenApi\Annotations\Schema;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\Router;
+
+/**
+ * Class CrudDocumentationFactory
+ *
+ * Feel free to extends and redefine some of the methods of the
+ */
+class CrudDocumentationFactory implements DocumentationFactoryInterface
+{
+    public const DOCUMENTATION_TAG = 'documentation_tag';
+    public const DOCUMENTATION_SUMMARY = 'documentation_summary';
+    public const DOCUMENTATION_DESCRIPTION = 'documentation_description';
+
+    /** @var DocumentationFactoryInterface */
+    private $decorated;
+
+    /** @var Router */
+    private $router;
+
+    /** @var string */
+    private $basePath;
+
+    public function __construct(DocumentationFactoryInterface $decoratedFactory, Router $router, string $basePath)
+    {
+        $this->decorated = $decoratedFactory;
+        $this->router = $router;
+        $this->basePath = $basePath;
+    }
+
+    public function createOpenApiAnalysis(): Analysis
+    {
+        $analysis = $this->decorated->createOpenApiAnalysis();
+
+        foreach ($this->router->getRouteCollection() as $route) {
+            /** @var Route $route */
+            $controller = $route->getDefaults()['_controller'] ?? null;
+            if ($controller === 'melodiia.crud.controller.get') {
+                $analysis->addAnnotation($this->createDocForGet($route), null);
+            }
+            if ($controller === 'melodiia.crud.controller.create') {
+                $analysis->addAnnotation($this->createDocForCreate($route), null);
+            }
+        }
+
+        return $analysis;
+    }
+
+    protected function createDocForGet(Route $route)
+    {
+        $defaults = $route->getDefaults();
+        $model = $this->getModelName($defaults[CrudControllerInterface::MODEL_ATTRIBUTE]);
+        $tag = $model;
+
+        if (isset($defaults[self::DOCUMENTATION_TAG])) {
+            $tag = $defaults[self::DOCUMENTATION_TAG];
+        }
+
+        $annot = new Get([
+            'path' => $this->cleanPath($route->getPath()),
+            'responses' => [
+                new Response([
+                    'response' => 200,
+                    'description' => 'Resource exists and is returned.',
+                    'content' => [
+                        new MediaType([
+                            'mediaType' => 'application/json',
+                            'schema' => new Schema([
+                               'ref' => '#ref/components/schemas/' . $model
+                            ])
+                        ])
+                    ]
+                ]),
+                new Response([
+                    'response' => 404,
+                    'description' => 'Resource doesn\'t exist.',
+                ])
+            ],
+            'operationId' => $model . ':get',
+            'parameters' => [
+                new Parameter([
+                    'name' => 'id',
+                    'in' => 'path',
+                    'description' => 'Id of the resource',
+                    'required' => true,
+                    'ref' => '#ref/components/schemas/Id',
+                    'schema' => new Schema([
+                        'type' => 'string',
+                        'schema' => 'id'
+                    ])
+                ])
+            ],
+            'summary' => $defaults[self::DOCUMENTATION_SUMMARY] ?? 'Return a resource',
+            'description' => $defaults[self::DOCUMENTATION_DESCRIPTION] ?? 'Return the ressource based on given id',
+            'tags' => [$tag]
+        ]);
+
+        return $annot;
+    }
+
+    public function createDocForCreate(Route $route)
+    {
+        $defaults = $route->getDefaults();
+        $model = $this->getModelName($defaults[CrudControllerInterface::MODEL_ATTRIBUTE]);
+        $tag = $model;
+
+        if (isset($defaults[self::DOCUMENTATION_TAG])) {
+            $tag = $defaults[self::DOCUMENTATION_TAG];
+        }
+
+        $annot = new Post([
+            'path' => $this->cleanPath($route->getPath()),
+            'responses' => [
+                new Response([
+                    'response' => 201,
+                    'description' => 'Resource created.'
+                ])
+            ],
+            'operationId' => $model . ':get',
+            'summary' => $defaults[self::DOCUMENTATION_SUMMARY] ?? 'Create a resource',
+            'description' => $defaults[self::DOCUMENTATION_DESCRIPTION] ?? 'Return the id of the created resource',
+            'tags' => [$tag]
+        ]);
+
+        return $annot;
+    }
+
+    protected function cleanPath(string $path): string
+    {
+        return StringTools::removeStart($path, rtrim($this->basePath, '/'));
+    }
+
+    protected function getModelName(string $fqcn): string
+    {
+        $model = explode('\\', $fqcn);
+        $model = end($model);
+
+        return $model;
+    }
+
+    private static function crudServices()
+    {
+        return [
+            'melodiia.crud.controller.create',
+            'melodiia.crud.controller.get'
+        ];
+    }
+}

--- a/src/Documentation/OpenApiDocFactory.php
+++ b/src/Documentation/OpenApiDocFactory.php
@@ -15,8 +15,12 @@ use Symfony\Component\HttpFoundation\RequestStack;
  */
 final class OpenApiDocFactory implements DocumentationFactoryInterface
 {
+    /** @var RequestStack */
     private $requestStack;
+
+    /** @var array */
     private $config;
+
 
     public function __construct(RequestStack $requestStack, array $config)
     {
@@ -34,7 +38,7 @@ final class OpenApiDocFactory implements DocumentationFactoryInterface
             ]),
             'paths' => [],
             'servers' => [
-                ['url' => $this->getApiPath()],
+                ['url' => 'http://' . $this->getApiPath()],
             ],
         ];
 
@@ -48,7 +52,7 @@ final class OpenApiDocFactory implements DocumentationFactoryInterface
 
     private function getApiPath()
     {
-        $path = $this->config['basePath'];
+        $path = $this->config['base_path'];
         if (!StringTools::startsWith($path, '/')) {
             $path = '/' . $path;
         }

--- a/tests/Melodiia/Bridge/Symfony/Routing/CrudDocumentationFactoryTest.php
+++ b/tests/Melodiia/Bridge/Symfony/Routing/CrudDocumentationFactoryTest.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace Biig\Melodiia\Test\Bridge\Symfony\Routing;
+
+use Biig\Melodiia\Bridge\Symfony\Routing\CrudDocumentationFactory;
+use Biig\Melodiia\Crud\CrudControllerInterface;
+use Biig\Melodiia\Documentation\Controller\OpenApiJsonController;
+use Biig\Melodiia\Documentation\DocumentationFactoryInterface;
+use Biig\Melodiia\Documentation\OpenApiDocFactory;
+use GuzzleHttp\Client;
+use Nekland\Utils\Tempfile\TemporaryDirectory;
+use OpenApi\Analysis;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Prophecy\ObjectProphecy;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCollection;
+use Symfony\Component\Routing\Router;
+
+class CrudDocumentationFactoryTest extends TestCase
+{
+    /** @var DocumentationFactoryInterface|ObjectProphecy */
+    private $decorated;
+
+    /** @var Router|ObjectProphecy */
+    private $router;
+
+    /** @var CrudDocumentationFactory */
+    private $factory;
+
+    public function setUp()
+    {
+        $this->decorated = $this->prophesize(DocumentationFactoryInterface::class);
+        $this->router = $this->prophesize(Router::class);
+        $this->factory = new CrudDocumentationFactory($this->decorated->reveal(), $this->router->reveal(), '/api/v1');
+    }
+
+    public function testItIsInstanceOfDocumentationFactoryInterface()
+    {
+        $this->assertInstanceOf(DocumentationFactoryInterface::class, $this->factory);
+    }
+
+    public function testItDoesNothingIfNoControllerFound()
+    {
+        $route = new Route('/foo');
+        $routeCollection = new RouteCollection();
+        $routeCollection->add('foo', $route);
+
+        $this->router->getRouteCollection()->willReturn($routeCollection);
+        $analysis = $this->prophesize(Analysis::class);
+        $analysis->addAnnotation()->shouldNotBeCalled();
+        $this->decorated->createOpenApiAnalysis()->willReturn($analysis->reveal());
+
+        $this->assertNotNull($this->factory->createOpenApiAnalysis());
+    }
+
+    public function testItGenerateValidOpenApiDoc()
+    {
+        // Mocks
+        $request = $this->prophesize(Request::class);
+        $request->getHttpHost()->willReturn('http://localhost:9999');
+        $requestStack = $this->prophesize(RequestStack::class);
+        $requestStack->getMasterRequest()->willReturn($request->reveal());
+
+        $route1 = new Route(
+            '/foo',
+            [
+                '_controller' => 'melodiia.crud.controller.get',
+                CrudControllerInterface::MODEL_ATTRIBUTE => FakeModel::class,
+                CrudDocumentationFactory::DOCUMENTATION_SUMMARY => 'Get a fake model',
+            ],
+            [], [], '', [], ['GET']
+        );
+        $route2 = new Route(
+            '/bar',
+            [
+                '_controller' => 'melodiia.crud.controller.create',
+                CrudControllerInterface::MODEL_ATTRIBUTE => FakeModel::class,
+            ],
+            [], [], '', [], ['POST']
+        );
+        $collection = new RouteCollection();
+        $collection->add('route1', $route1);
+        $collection->add('route2', $route2);
+
+        $this->router->getRouteCollection()->willReturn($collection);
+
+        $tmpDir = new TemporaryDirectory();
+
+        // Real objects
+        $decorated = new OpenApiDocFactory($requestStack->reveal(), ['base_path' => '/api/v1/', 'title' => 'Awesome API', 'version' => '1.0.0', 'description' => 'Awesome API is Awesome']);
+        $factory = new CrudDocumentationFactory($decorated, $this->router->reveal(), '/api/v1/');
+        $controller = new OpenApiJsonController([$tmpDir->getPathname()], $factory);
+
+        // Test
+        $response = $controller();
+        $json = $response->getContent();
+
+        // OpenApi format check
+        $json = json_decode($json);
+        $validator = new \JsonSchema\Validator;
+        $validator->validate(
+            $json,
+            (object)['$ref' => 'file://' . realpath(__DIR__ . '/../../../../openapi3-schema.json')]
+        );
+        // Get errors with $validator->getErrors()
+        $this->assertTrue($validator->isValid());
+
+        $tmpDir->remove();
+    }
+}
+
+
+class FakeModel {
+    private $foo;
+
+    /**
+     * FakeModel constructor.
+     *
+     * @param $foo
+     */
+    public function __construct($foo)
+    {
+        $this->foo = $foo;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getFoo()
+    {
+        return $this->foo;
+    }
+
+    /**
+     * @param mixed $foo
+     */
+    public function setFoo($foo): void
+    {
+        $this->foo = $foo;
+    }
+
+}

--- a/tests/Melodiia/Documentation/OpenApiDocFactoryTest.php
+++ b/tests/Melodiia/Documentation/OpenApiDocFactoryTest.php
@@ -31,7 +31,7 @@ class OpenApiDocFactoryTest extends TestCase
         $factory = $this->createFactory([
             'title' => 'hello',
             'version' => '1.0.0',
-            'basePath' => '/foo',
+            'base_path' => '/foo',
             'description' => null,
         ]);
         $request = $this->prophesize(Request::class);

--- a/tests/openapi3-schema.json
+++ b/tests/openapi3-schema.json
@@ -1,0 +1,2288 @@
+{
+    "type": "object",
+    "required": [
+        "openapi",
+        "info",
+        "paths"
+    ],
+    "properties": {
+        "openapi": {
+            "type": "string",
+            "pattern": "^3\\.0\\.\\d(-.+)?$"
+        },
+        "info": {
+            "$ref": "#/definitions/Info"
+        },
+        "externalDocs": {
+            "$ref": "#/definitions/ExternalDocumentation"
+        },
+        "servers": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/Server"
+            }
+        },
+        "security": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/SecurityRequirement"
+            }
+        },
+        "tags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/Tag"
+            },
+            "uniqueItems": true
+        },
+        "paths": {
+            "$ref": "#/definitions/Paths"
+        },
+        "components": {
+            "$ref": "#/definitions/Components"
+        }
+    },
+    "patternProperties": {
+        "^x-": {}
+    },
+    "additionalProperties": false,
+    "definitions": {
+        "Reference": {
+            "type": "object",
+            "required": [
+                "$ref"
+            ],
+            "patternProperties": {
+                "^\\$ref$": {
+                    "type": "string",
+                    "format": "uri-reference"
+                }
+            }
+        },
+        "Info": {
+            "type": "object",
+            "required": [
+                "title",
+                "version"
+            ],
+            "properties": {
+                "title": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "termsOfService": {
+                    "type": "string",
+                    "format": "uri-reference"
+                },
+                "contact": {
+                    "$ref": "#/definitions/Contact"
+                },
+                "license": {
+                    "$ref": "#/definitions/License"
+                },
+                "version": {
+                    "type": "string"
+                }
+            },
+            "patternProperties": {
+                "^x-": {}
+            },
+            "additionalProperties": false
+        },
+        "Contact": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string",
+                    "format": "uri-reference"
+                },
+                "email": {
+                    "type": "string",
+                    "format": "email"
+                }
+            },
+            "patternProperties": {
+                "^x-": {}
+            },
+            "additionalProperties": false
+        },
+        "License": {
+            "type": "object",
+            "required": [
+                "name"
+            ],
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string",
+                    "format": "uri-reference"
+                }
+            },
+            "patternProperties": {
+                "^x-": {}
+            },
+            "additionalProperties": false
+        },
+        "Server": {
+            "type": "object",
+            "required": [
+                "url"
+            ],
+            "properties": {
+                "url": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "variables": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/ServerVariable"
+                    }
+                }
+            },
+            "patternProperties": {
+                "^x-": {}
+            },
+            "additionalProperties": false
+        },
+        "ServerVariable": {
+            "type": "object",
+            "required": [
+                "default"
+            ],
+            "properties": {
+                "enum": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "default": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                }
+            },
+            "patternProperties": {
+                "^x-": {}
+            },
+            "additionalProperties": false
+        },
+        "Components": {
+            "type": "object",
+            "properties": {
+                "schemas": {
+                    "type": "object",
+                    "patternProperties": {
+                        "^[a-zA-Z0-9\\.\\-_]+$": {
+                            "oneOf": [
+                                {
+                                    "$ref": "#/definitions/Reference"
+                                },
+                                {
+                                    "$ref": "#/definitions/Schema"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "responses": {
+                    "type": "object",
+                    "patternProperties": {
+                        "^[a-zA-Z0-9\\.\\-_]+$": {
+                            "oneOf": [
+                                {
+                                    "$ref": "#/definitions/Reference"
+                                },
+                                {
+                                    "$ref": "#/definitions/Response"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "parameters": {
+                    "type": "object",
+                    "patternProperties": {
+                        "^[a-zA-Z0-9\\.\\-_]+$": {
+                            "oneOf": [
+                                {
+                                    "$ref": "#/definitions/Reference"
+                                },
+                                {
+                                    "$ref": "#/definitions/Parameter"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "examples": {
+                    "type": "object",
+                    "patternProperties": {
+                        "^[a-zA-Z0-9\\.\\-_]+$": {
+                            "oneOf": [
+                                {
+                                    "$ref": "#/definitions/Reference"
+                                },
+                                {
+                                    "$ref": "#/definitions/Example"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "requestBodies": {
+                    "type": "object",
+                    "patternProperties": {
+                        "^[a-zA-Z0-9\\.\\-_]+$": {
+                            "oneOf": [
+                                {
+                                    "$ref": "#/definitions/Reference"
+                                },
+                                {
+                                    "$ref": "#/definitions/RequestBody"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "headers": {
+                    "type": "object",
+                    "patternProperties": {
+                        "^[a-zA-Z0-9\\.\\-_]+$": {
+                            "oneOf": [
+                                {
+                                    "$ref": "#/definitions/Reference"
+                                },
+                                {
+                                    "$ref": "#/definitions/Header"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "securitySchemes": {
+                    "type": "object",
+                    "patternProperties": {
+                        "^[a-zA-Z0-9\\.\\-_]+$": {
+                            "oneOf": [
+                                {
+                                    "$ref": "#/definitions/Reference"
+                                },
+                                {
+                                    "$ref": "#/definitions/SecurityScheme"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "links": {
+                    "type": "object",
+                    "patternProperties": {
+                        "^[a-zA-Z0-9\\.\\-_]+$": {
+                            "oneOf": [
+                                {
+                                    "$ref": "#/definitions/Reference"
+                                },
+                                {
+                                    "$ref": "#/definitions/Link"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "callbacks": {
+                    "type": "object",
+                    "patternProperties": {
+                        "^[a-zA-Z0-9\\.\\-_]+$": {
+                            "oneOf": [
+                                {
+                                    "$ref": "#/definitions/Reference"
+                                },
+                                {
+                                    "$ref": "#/definitions/Callback"
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+            "patternProperties": {
+                "^x-": {}
+            },
+            "additionalProperties": false
+        },
+        "Schema": {
+            "type": "object",
+            "properties": {
+                "title": {
+                    "type": "string"
+                },
+                "multipleOf": {
+                    "type": "number",
+                    "minimum": 0,
+                    "exclusiveMinimum": true
+                },
+                "maximum": {
+                    "type": "number"
+                },
+                "exclusiveMaximum": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "minimum": {
+                    "type": "number"
+                },
+                "exclusiveMinimum": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "maxLength": {
+                    "type": "integer",
+                    "minimum": 0
+                },
+                "minLength": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "default": 0
+                },
+                "pattern": {
+                    "type": "string",
+                    "format": "regex"
+                },
+                "maxItems": {
+                    "type": "integer",
+                    "minimum": 0
+                },
+                "minItems": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "default": 0
+                },
+                "uniqueItems": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "maxProperties": {
+                    "type": "integer",
+                    "minimum": 0
+                },
+                "minProperties": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "default": 0
+                },
+                "required": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "minItems": 1,
+                    "uniqueItems": true
+                },
+                "enum": {
+                    "type": "array",
+                    "items": {},
+                    "minItems": 1,
+                    "uniqueItems": false
+                },
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "object",
+                        "string"
+                    ]
+                },
+                "not": {
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/Schema"
+                        },
+                        {
+                            "$ref": "#/definitions/Reference"
+                        }
+                    ]
+                },
+                "allOf": {
+                    "type": "array",
+                    "items": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/definitions/Schema"
+                            },
+                            {
+                                "$ref": "#/definitions/Reference"
+                            }
+                        ]
+                    }
+                },
+                "oneOf": {
+                    "type": "array",
+                    "items": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/definitions/Schema"
+                            },
+                            {
+                                "$ref": "#/definitions/Reference"
+                            }
+                        ]
+                    }
+                },
+                "anyOf": {
+                    "type": "array",
+                    "items": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/definitions/Schema"
+                            },
+                            {
+                                "$ref": "#/definitions/Reference"
+                            }
+                        ]
+                    }
+                },
+                "items": {
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/Schema"
+                        },
+                        {
+                            "$ref": "#/definitions/Reference"
+                        }
+                    ]
+                },
+                "properties": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/definitions/Schema"
+                            },
+                            {
+                                "$ref": "#/definitions/Reference"
+                            }
+                        ]
+                    }
+                },
+                "additionalProperties": {
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/Schema"
+                        },
+                        {
+                            "$ref": "#/definitions/Reference"
+                        },
+                        {
+                            "type": "boolean"
+                        }
+                    ],
+                    "default": true
+                },
+                "description": {
+                    "type": "string"
+                },
+                "format": {
+                    "type": "string"
+                },
+                "default": {},
+                "nullable": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "discriminator": {
+                    "$ref": "#/definitions/Discriminator"
+                },
+                "readOnly": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "writeOnly": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "example": {},
+                "externalDocs": {
+                    "$ref": "#/definitions/ExternalDocumentation"
+                },
+                "deprecated": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "xml": {
+                    "$ref": "#/definitions/XML"
+                }
+            },
+            "patternProperties": {
+                "^x-": {}
+            },
+            "additionalProperties": false
+        },
+        "Discriminator": {
+            "type": "object",
+            "required": [
+                "propertyName"
+            ],
+            "properties": {
+                "propertyName": {
+                    "type": "string"
+                },
+                "mapping": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "XML": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "namespace": {
+                    "type": "string",
+                    "format": "uri"
+                },
+                "prefix": {
+                    "type": "string"
+                },
+                "attribute": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "wrapped": {
+                    "type": "boolean",
+                    "default": false
+                }
+            },
+            "patternProperties": {
+                "^x-": {}
+            },
+            "additionalProperties": false
+        },
+        "Response": {
+            "type": "object",
+            "required": [
+                "description"
+            ],
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "headers": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/definitions/Header"
+                            },
+                            {
+                                "$ref": "#/definitions/Reference"
+                            }
+                        ]
+                    }
+                },
+                "content": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/MediaType"
+                    }
+                },
+                "links": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/definitions/Link"
+                            },
+                            {
+                                "$ref": "#/definitions/Reference"
+                            }
+                        ]
+                    }
+                }
+            },
+            "patternProperties": {
+                "^x-": {}
+            },
+            "additionalProperties": false
+        },
+        "MediaType": {
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/MediaTypeWithExample"
+                },
+                {
+                    "$ref": "#/definitions/MediaTypeWithExamples"
+                }
+            ]
+        },
+        "MediaTypeWithExample": {
+            "type": "object",
+            "properties": {
+                "schema": {
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/Schema"
+                        },
+                        {
+                            "$ref": "#/definitions/Reference"
+                        }
+                    ]
+                },
+                "example": {},
+                "encoding": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/Encoding"
+                    }
+                }
+            },
+            "patternProperties": {
+                "^x-": {}
+            },
+            "additionalProperties": false
+        },
+        "MediaTypeWithExamples": {
+            "type": "object",
+            "required": [
+                "examples"
+            ],
+            "properties": {
+                "schema": {
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/Schema"
+                        },
+                        {
+                            "$ref": "#/definitions/Reference"
+                        }
+                    ]
+                },
+                "examples": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/definitions/Example"
+                            },
+                            {
+                                "$ref": "#/definitions/Reference"
+                            }
+                        ]
+                    }
+                },
+                "encoding": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/Encoding"
+                    }
+                }
+            },
+            "patternProperties": {
+                "^x-": {}
+            },
+            "additionalProperties": false
+        },
+        "Example": {
+            "type": "object",
+            "properties": {
+                "summary": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "value": {},
+                "externalValue": {
+                    "type": "string",
+                    "format": "uri-reference"
+                }
+            },
+            "patternProperties": {
+                "^x-": {}
+            },
+            "additionalProperties": false
+        },
+        "Header": {
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/HeaderWithSchema"
+                },
+                {
+                    "$ref": "#/definitions/HeaderWithContent"
+                }
+            ]
+        },
+        "HeaderWithSchema": {
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/HeaderWithSchemaWithExample"
+                },
+                {
+                    "$ref": "#/definitions/HeaderWithSchemaWithExamples"
+                }
+            ]
+        },
+        "HeaderWithSchemaWithExample": {
+            "type": "object",
+            "required": [
+                "schema"
+            ],
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "required": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "deprecated": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "allowEmptyValue": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "style": {
+                    "type": "string",
+                    "enum": [
+                        "simple"
+                    ],
+                    "default": "simple"
+                },
+                "explode": {
+                    "type": "boolean"
+                },
+                "allowReserved": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "schema": {
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/Schema"
+                        },
+                        {
+                            "$ref": "#/definitions/Reference"
+                        }
+                    ]
+                },
+                "example": {}
+            },
+            "patternProperties": {
+                "^x-": {}
+            },
+            "additionalProperties": false
+        },
+        "HeaderWithSchemaWithExamples": {
+            "type": "object",
+            "required": [
+                "schema",
+                "examples"
+            ],
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "required": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "deprecated": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "allowEmptyValue": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "style": {
+                    "type": "string",
+                    "enum": [
+                        "simple"
+                    ],
+                    "default": "simple"
+                },
+                "explode": {
+                    "type": "boolean"
+                },
+                "allowReserved": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "schema": {
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/Schema"
+                        },
+                        {
+                            "$ref": "#/definitions/Reference"
+                        }
+                    ]
+                },
+                "examples": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/definitions/Example"
+                            },
+                            {
+                                "$ref": "#/definitions/Reference"
+                            }
+                        ]
+                    }
+                }
+            },
+            "patternProperties": {
+                "^x-": {}
+            },
+            "additionalProperties": false
+        },
+        "HeaderWithContent": {
+            "type": "object",
+            "required": [
+                "content"
+            ],
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "required": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "deprecated": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "allowEmptyValue": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "content": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/MediaType"
+                    },
+                    "minProperties": 1,
+                    "maxProperties": 1
+                }
+            },
+            "patternProperties": {
+                "^x-": {}
+            },
+            "additionalProperties": false
+        },
+        "Paths": {
+            "type": "object",
+            "patternProperties": {
+                "^\\/": {
+                    "$ref": "#/definitions/PathItem"
+                },
+                "^x-": {}
+            },
+            "additionalProperties": false
+        },
+        "PathItem": {
+            "type": "object",
+            "properties": {
+                "$ref": {
+                    "type": "string"
+                },
+                "summary": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "get": {
+                    "$ref": "#/definitions/Operation"
+                },
+                "put": {
+                    "$ref": "#/definitions/Operation"
+                },
+                "post": {
+                    "$ref": "#/definitions/Operation"
+                },
+                "delete": {
+                    "$ref": "#/definitions/Operation"
+                },
+                "options": {
+                    "$ref": "#/definitions/Operation"
+                },
+                "head": {
+                    "$ref": "#/definitions/Operation"
+                },
+                "patch": {
+                    "$ref": "#/definitions/Operation"
+                },
+                "trace": {
+                    "$ref": "#/definitions/Operation"
+                },
+                "servers": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Server"
+                    }
+                },
+                "parameters": {
+                    "type": "array",
+                    "items": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/definitions/Parameter"
+                            },
+                            {
+                                "$ref": "#/definitions/Reference"
+                            }
+                        ]
+                    },
+                    "uniqueItems": true
+                }
+            },
+            "patternProperties": {
+                "^x-": {}
+            },
+            "additionalProperties": false
+        },
+        "Operation": {
+            "type": "object",
+            "required": [
+                "responses"
+            ],
+            "properties": {
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "summary": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "externalDocs": {
+                    "$ref": "#/definitions/ExternalDocumentation"
+                },
+                "operationId": {
+                    "type": "string"
+                },
+                "parameters": {
+                    "type": "array",
+                    "items": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/definitions/Parameter"
+                            },
+                            {
+                                "$ref": "#/definitions/Reference"
+                            }
+                        ]
+                    },
+                    "uniqueItems": true
+                },
+                "requestBody": {
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/RequestBody"
+                        },
+                        {
+                            "$ref": "#/definitions/Reference"
+                        }
+                    ]
+                },
+                "responses": {
+                    "$ref": "#/definitions/Responses"
+                },
+                "callbacks": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/definitions/Callback"
+                            },
+                            {
+                                "$ref": "#/definitions/Reference"
+                            }
+                        ]
+                    }
+                },
+                "deprecated": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "security": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/SecurityRequirement"
+                    }
+                },
+                "servers": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Server"
+                    }
+                }
+            },
+            "patternProperties": {
+                "^x-": {}
+            },
+            "additionalProperties": false
+        },
+        "Responses": {
+            "type": "object",
+            "properties": {
+                "default": {
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/Response"
+                        },
+                        {
+                            "$ref": "#/definitions/Reference"
+                        }
+                    ]
+                }
+            },
+            "patternProperties": {
+                "^[1-5](?:\\d{2}|XX)$": {
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/Response"
+                        },
+                        {
+                            "$ref": "#/definitions/Reference"
+                        }
+                    ]
+                },
+                "^x-": {}
+            },
+            "minProperties": 1,
+            "additionalProperties": false
+        },
+        "SecurityRequirement": {
+            "type": "object",
+            "additionalProperties": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+            }
+        },
+        "Tag": {
+            "type": "object",
+            "required": [
+                "name"
+            ],
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "externalDocs": {
+                    "$ref": "#/definitions/ExternalDocumentation"
+                }
+            },
+            "patternProperties": {
+                "^x-": {}
+            },
+            "additionalProperties": false
+        },
+        "ExternalDocumentation": {
+            "type": "object",
+            "required": [
+                "url"
+            ],
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string",
+                    "format": "uri-reference"
+                }
+            },
+            "patternProperties": {
+                "^x-": {}
+            },
+            "additionalProperties": false
+        },
+        "Parameter": {
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/ParameterWithSchema"
+                },
+                {
+                    "$ref": "#/definitions/ParameterWithContent"
+                }
+            ]
+        },
+        "ParameterWithSchema": {
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/ParameterWithSchemaWithExample"
+                },
+                {
+                    "$ref": "#/definitions/ParameterWithSchemaWithExamples"
+                }
+            ]
+        },
+        "ParameterWithSchemaWithExample": {
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/ParameterWithSchemaWithExampleInPath"
+                },
+                {
+                    "$ref": "#/definitions/ParameterWithSchemaWithExampleInQuery"
+                },
+                {
+                    "$ref": "#/definitions/ParameterWithSchemaWithExampleInHeader"
+                },
+                {
+                    "$ref": "#/definitions/ParameterWithSchemaWithExampleInCookie"
+                }
+            ]
+        },
+        "ParameterWithSchemaWithExampleInPath": {
+            "type": "object",
+            "required": [
+                "name",
+                "in",
+                "schema",
+                "required"
+            ],
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "in": {
+                    "type": "string",
+                    "enum": [
+                        "path"
+                    ]
+                },
+                "description": {
+                    "type": "string"
+                },
+                "required": {
+                    "type": "boolean",
+                    "enum": [
+                        true
+                    ]
+                },
+                "deprecated": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "allowEmptyValue": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "style": {
+                    "type": "string",
+                    "enum": [
+                        "matrix",
+                        "label",
+                        "simple"
+                    ],
+                    "default": "simple"
+                },
+                "explode": {
+                    "type": "boolean"
+                },
+                "allowReserved": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "schema": {
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/Schema"
+                        },
+                        {
+                            "$ref": "#/definitions/Reference"
+                        }
+                    ]
+                },
+                "example": {}
+            },
+            "patternProperties": {
+                "^x-": {}
+            },
+            "additionalProperties": false
+        },
+        "ParameterWithSchemaWithExampleInQuery": {
+            "type": "object",
+            "required": [
+                "name",
+                "in",
+                "schema"
+            ],
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "in": {
+                    "type": "string",
+                    "enum": [
+                        "query"
+                    ]
+                },
+                "description": {
+                    "type": "string"
+                },
+                "required": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "deprecated": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "allowEmptyValue": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "style": {
+                    "type": "string",
+                    "enum": [
+                        "form",
+                        "spaceDelimited",
+                        "pipeDelimited",
+                        "deepObject"
+                    ],
+                    "default": "form"
+                },
+                "explode": {
+                    "type": "boolean"
+                },
+                "allowReserved": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "schema": {
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/Schema"
+                        },
+                        {
+                            "$ref": "#/definitions/Reference"
+                        }
+                    ]
+                },
+                "example": {}
+            },
+            "patternProperties": {
+                "^x-": {}
+            },
+            "additionalProperties": false
+        },
+        "ParameterWithSchemaWithExampleInHeader": {
+            "type": "object",
+            "required": [
+                "name",
+                "in",
+                "schema"
+            ],
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "in": {
+                    "type": "string",
+                    "enum": [
+                        "header"
+                    ]
+                },
+                "description": {
+                    "type": "string"
+                },
+                "required": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "deprecated": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "allowEmptyValue": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "style": {
+                    "type": "string",
+                    "enum": [
+                        "simple"
+                    ],
+                    "default": "simple"
+                },
+                "explode": {
+                    "type": "boolean"
+                },
+                "allowReserved": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "schema": {
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/Schema"
+                        },
+                        {
+                            "$ref": "#/definitions/Reference"
+                        }
+                    ]
+                },
+                "example": {}
+            },
+            "patternProperties": {
+                "^x-": {}
+            },
+            "additionalProperties": false
+        },
+        "ParameterWithSchemaWithExampleInCookie": {
+            "type": "object",
+            "required": [
+                "name",
+                "in",
+                "schema"
+            ],
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "in": {
+                    "type": "string",
+                    "enum": [
+                        "cookie"
+                    ]
+                },
+                "description": {
+                    "type": "string"
+                },
+                "required": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "deprecated": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "allowEmptyValue": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "style": {
+                    "type": "string",
+                    "enum": [
+                        "form"
+                    ],
+                    "default": "form"
+                },
+                "explode": {
+                    "type": "boolean"
+                },
+                "allowReserved": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "schema": {
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/Schema"
+                        },
+                        {
+                            "$ref": "#/definitions/Reference"
+                        }
+                    ]
+                },
+                "example": {}
+            },
+            "patternProperties": {
+                "^x-": {}
+            },
+            "additionalProperties": false
+        },
+        "ParameterWithSchemaWithExamples": {
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/ParameterWithSchemaWithExamplesInPath"
+                },
+                {
+                    "$ref": "#/definitions/ParameterWithSchemaWithExamplesInQuery"
+                },
+                {
+                    "$ref": "#/definitions/ParameterWithSchemaWithExamplesInHeader"
+                },
+                {
+                    "$ref": "#/definitions/ParameterWithSchemaWithExamplesInCookie"
+                }
+            ]
+        },
+        "ParameterWithSchemaWithExamplesInPath": {
+            "type": "object",
+            "required": [
+                "name",
+                "in",
+                "schema",
+                "required",
+                "examples"
+            ],
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "in": {
+                    "type": "string",
+                    "enum": [
+                        "path"
+                    ]
+                },
+                "description": {
+                    "type": "string"
+                },
+                "required": {
+                    "type": "boolean",
+                    "enum": [
+                        true
+                    ]
+                },
+                "deprecated": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "allowEmptyValue": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "style": {
+                    "type": "string",
+                    "enum": [
+                        "matrix",
+                        "label",
+                        "simple"
+                    ],
+                    "default": "simple"
+                },
+                "explode": {
+                    "type": "boolean"
+                },
+                "allowReserved": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "schema": {
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/Schema"
+                        },
+                        {
+                            "$ref": "#/definitions/Reference"
+                        }
+                    ]
+                },
+                "examples": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/definitions/Example"
+                            },
+                            {
+                                "$ref": "#/definitions/Reference"
+                            }
+                        ]
+                    }
+                }
+            },
+            "patternProperties": {
+                "^x-": {}
+            },
+            "additionalProperties": false
+        },
+        "ParameterWithSchemaWithExamplesInQuery": {
+            "type": "object",
+            "required": [
+                "name",
+                "in",
+                "schema",
+                "examples"
+            ],
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "in": {
+                    "type": "string",
+                    "enum": [
+                        "query"
+                    ]
+                },
+                "description": {
+                    "type": "string"
+                },
+                "required": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "deprecated": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "allowEmptyValue": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "style": {
+                    "type": "string",
+                    "enum": [
+                        "form",
+                        "spaceDelimited",
+                        "pipeDelimited",
+                        "deepObject"
+                    ],
+                    "default": "form"
+                },
+                "explode": {
+                    "type": "boolean"
+                },
+                "allowReserved": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "schema": {
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/Schema"
+                        },
+                        {
+                            "$ref": "#/definitions/Reference"
+                        }
+                    ]
+                },
+                "examples": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/definitions/Example"
+                            },
+                            {
+                                "$ref": "#/definitions/Reference"
+                            }
+                        ]
+                    }
+                }
+            },
+            "patternProperties": {
+                "^x-": {}
+            },
+            "additionalProperties": false
+        },
+        "ParameterWithSchemaWithExamplesInHeader": {
+            "type": "object",
+            "required": [
+                "name",
+                "in",
+                "schema",
+                "examples"
+            ],
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "in": {
+                    "type": "string",
+                    "enum": [
+                        "header"
+                    ]
+                },
+                "description": {
+                    "type": "string"
+                },
+                "required": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "deprecated": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "allowEmptyValue": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "style": {
+                    "type": "string",
+                    "enum": [
+                        "simple"
+                    ],
+                    "default": "simple"
+                },
+                "explode": {
+                    "type": "boolean"
+                },
+                "allowReserved": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "schema": {
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/Schema"
+                        },
+                        {
+                            "$ref": "#/definitions/Reference"
+                        }
+                    ]
+                },
+                "examples": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/definitions/Example"
+                            },
+                            {
+                                "$ref": "#/definitions/Reference"
+                            }
+                        ]
+                    }
+                }
+            },
+            "patternProperties": {
+                "^x-": {}
+            },
+            "additionalProperties": false
+        },
+        "ParameterWithSchemaWithExamplesInCookie": {
+            "type": "object",
+            "required": [
+                "name",
+                "in",
+                "schema",
+                "examples"
+            ],
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "in": {
+                    "type": "string",
+                    "enum": [
+                        "cookie"
+                    ]
+                },
+                "description": {
+                    "type": "string"
+                },
+                "required": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "deprecated": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "allowEmptyValue": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "style": {
+                    "type": "string",
+                    "enum": [
+                        "form"
+                    ],
+                    "default": "form"
+                },
+                "explode": {
+                    "type": "boolean"
+                },
+                "allowReserved": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "schema": {
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/Schema"
+                        },
+                        {
+                            "$ref": "#/definitions/Reference"
+                        }
+                    ]
+                },
+                "examples": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/definitions/Example"
+                            },
+                            {
+                                "$ref": "#/definitions/Reference"
+                            }
+                        ]
+                    }
+                }
+            },
+            "patternProperties": {
+                "^x-": {}
+            },
+            "additionalProperties": false
+        },
+        "ParameterWithContent": {
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/ParameterWithContentInPath"
+                },
+                {
+                    "$ref": "#/definitions/ParameterWithContentNotInPath"
+                }
+            ]
+        },
+        "ParameterWithContentInPath": {
+            "type": "object",
+            "required": [
+                "name",
+                "in",
+                "content"
+            ],
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "in": {
+                    "type": "string",
+                    "enum": [
+                        "path"
+                    ]
+                },
+                "description": {
+                    "type": "string"
+                },
+                "required": {
+                    "type": "boolean",
+                    "enum": [
+                        true
+                    ]
+                },
+                "deprecated": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "allowEmptyValue": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "content": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/MediaType"
+                    },
+                    "minProperties": 1,
+                    "maxProperties": 1
+                }
+            },
+            "patternProperties": {
+                "^x-": {}
+            },
+            "additionalProperties": false
+        },
+        "ParameterWithContentNotInPath": {
+            "type": "object",
+            "required": [
+                "name",
+                "in",
+                "content"
+            ],
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "in": {
+                    "type": "string",
+                    "enum": [
+                        "query",
+                        "header",
+                        "cookie"
+                    ]
+                },
+                "description": {
+                    "type": "string"
+                },
+                "required": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "deprecated": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "allowEmptyValue": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "content": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/MediaType"
+                    },
+                    "minProperties": 1,
+                    "maxProperties": 1
+                }
+            },
+            "patternProperties": {
+                "^x-": {}
+            },
+            "additionalProperties": false
+        },
+        "RequestBody": {
+            "type": "object",
+            "required": [
+                "content"
+            ],
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "content": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/MediaType"
+                    }
+                },
+                "required": {
+                    "type": "boolean",
+                    "default": false
+                }
+            },
+            "patternProperties": {
+                "^x-": {}
+            },
+            "additionalProperties": false
+        },
+        "SecurityScheme": {
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/APIKeySecurityScheme"
+                },
+                {
+                    "$ref": "#/definitions/HTTPSecurityScheme"
+                },
+                {
+                    "$ref": "#/definitions/OAuth2SecurityScheme"
+                },
+                {
+                    "$ref": "#/definitions/OpenIdConnectSecurityScheme"
+                }
+            ]
+        },
+        "APIKeySecurityScheme": {
+            "type": "object",
+            "required": [
+                "type",
+                "name",
+                "in"
+            ],
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "apiKey"
+                    ]
+                },
+                "name": {
+                    "type": "string"
+                },
+                "in": {
+                    "type": "string",
+                    "enum": [
+                        "header",
+                        "query",
+                        "cookie"
+                    ]
+                },
+                "description": {
+                    "type": "string"
+                }
+            },
+            "patternProperties": {
+                "^x-": {}
+            },
+            "additionalProperties": false
+        },
+        "HTTPSecurityScheme": {
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/NonBearerHTTPSecurityScheme"
+                },
+                {
+                    "$ref": "#/definitions/BearerHTTPSecurityScheme"
+                }
+            ]
+        },
+        "NonBearerHTTPSecurityScheme": {
+            "type": "object",
+            "required": [
+                "scheme",
+                "type"
+            ],
+            "properties": {
+                "scheme": {
+                    "type": "string",
+                    "not": {
+                        "enum": [
+                            "bearer"
+                        ]
+                    }
+                },
+                "description": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "http"
+                    ]
+                }
+            },
+            "patternProperties": {
+                "^x-": {}
+            },
+            "additionalProperties": false
+        },
+        "BearerHTTPSecurityScheme": {
+            "type": "object",
+            "required": [
+                "type",
+                "scheme"
+            ],
+            "properties": {
+                "scheme": {
+                    "type": "string",
+                    "enum": [
+                        "bearer"
+                    ]
+                },
+                "bearerFormat": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "http"
+                    ]
+                },
+                "description": {
+                    "type": "string"
+                }
+            },
+            "patternProperties": {
+                "^x-": {}
+            },
+            "additionalProperties": false
+        },
+        "OAuth2SecurityScheme": {
+            "type": "object",
+            "required": [
+                "type",
+                "flows"
+            ],
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "oauth2"
+                    ]
+                },
+                "flows": {
+                    "$ref": "#/definitions/OAuthFlows"
+                },
+                "description": {
+                    "type": "string"
+                }
+            },
+            "patternProperties": {
+                "^x-": {}
+            },
+            "additionalProperties": false
+        },
+        "OpenIdConnectSecurityScheme": {
+            "type": "object",
+            "required": [
+                "type",
+                "openIdConnectUrl"
+            ],
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "openIdConnect"
+                    ]
+                },
+                "openIdConnectUrl": {
+                    "type": "string",
+                    "format": "uri-reference"
+                },
+                "description": {
+                    "type": "string"
+                }
+            },
+            "patternProperties": {
+                "^x-": {}
+            },
+            "additionalProperties": false
+        },
+        "OAuthFlows": {
+            "type": "object",
+            "properties": {
+                "implicit": {
+                    "$ref": "#/definitions/ImplicitOAuthFlow"
+                },
+                "password": {
+                    "$ref": "#/definitions/PasswordOAuthFlow"
+                },
+                "clientCredentials": {
+                    "$ref": "#/definitions/ClientCredentialsFlow"
+                },
+                "authorizationCode": {
+                    "$ref": "#/definitions/AuthorizationCodeOAuthFlow"
+                }
+            },
+            "patternProperties": {
+                "^x-": {}
+            },
+            "additionalProperties": false
+        },
+        "ImplicitOAuthFlow": {
+            "type": "object",
+            "required": [
+                "authorizationUrl",
+                "scopes"
+            ],
+            "properties": {
+                "authorizationUrl": {
+                    "type": "string",
+                    "format": "uri-reference"
+                },
+                "refreshUrl": {
+                    "type": "string",
+                    "format": "uri-reference"
+                },
+                "scopes": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                }
+            },
+            "patternProperties": {
+                "^x-": {}
+            },
+            "additionalProperties": false
+        },
+        "PasswordOAuthFlow": {
+            "type": "object",
+            "required": [
+                "tokenUrl"
+            ],
+            "properties": {
+                "tokenUrl": {
+                    "type": "string",
+                    "format": "uri-reference"
+                },
+                "refreshUrl": {
+                    "type": "string",
+                    "format": "uri-reference"
+                },
+                "scopes": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                }
+            },
+            "patternProperties": {
+                "^x-": {}
+            },
+            "additionalProperties": false
+        },
+        "ClientCredentialsFlow": {
+            "type": "object",
+            "required": [
+                "tokenUrl"
+            ],
+            "properties": {
+                "tokenUrl": {
+                    "type": "string",
+                    "format": "uri-reference"
+                },
+                "refreshUrl": {
+                    "type": "string",
+                    "format": "uri-reference"
+                },
+                "scopes": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                }
+            },
+            "patternProperties": {
+                "^x-": {}
+            },
+            "additionalProperties": false
+        },
+        "AuthorizationCodeOAuthFlow": {
+            "type": "object",
+            "required": [
+                "authorizationUrl",
+                "tokenUrl"
+            ],
+            "properties": {
+                "authorizationUrl": {
+                    "type": "string",
+                    "format": "uri-reference"
+                },
+                "tokenUrl": {
+                    "type": "string",
+                    "format": "uri-reference"
+                },
+                "refreshUrl": {
+                    "type": "string",
+                    "format": "uri-reference"
+                },
+                "scopes": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                }
+            },
+            "patternProperties": {
+                "^x-": {}
+            },
+            "additionalProperties": false
+        },
+        "Link": {
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/LinkWithOperationRef"
+                },
+                {
+                    "$ref": "#/definitions/LinkWithOperationId"
+                }
+            ]
+        },
+        "LinkWithOperationRef": {
+            "type": "object",
+            "properties": {
+                "operationRef": {
+                    "type": "string",
+                    "format": "uri-reference"
+                },
+                "parameters": {
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "requestBody": {},
+                "description": {
+                    "type": "string"
+                },
+                "server": {
+                    "$ref": "#/definitions/Server"
+                }
+            },
+            "patternProperties": {
+                "^x-": {}
+            },
+            "additionalProperties": false
+        },
+        "LinkWithOperationId": {
+            "type": "object",
+            "properties": {
+                "operationId": {
+                    "type": "string"
+                },
+                "parameters": {
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "requestBody": {},
+                "description": {
+                    "type": "string"
+                },
+                "server": {
+                    "$ref": "#/definitions/Server"
+                }
+            },
+            "patternProperties": {
+                "^x-": {}
+            },
+            "additionalProperties": false
+        },
+        "Callback": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/PathItem"
+            },
+            "patternProperties": {
+                "^x-": {}
+            }
+        },
+        "Encoding": {
+            "type": "object",
+            "properties": {
+                "contentType": {
+                    "type": "string"
+                },
+                "headers": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/Header"
+                    }
+                },
+                "style": {
+                    "type": "string",
+                    "enum": [
+                        "form",
+                        "spaceDelimited",
+                        "pipeDelimited",
+                        "deepObject"
+                    ]
+                },
+                "explode": {
+                    "type": "boolean"
+                },
+                "allowReserved": {
+                    "type": "boolean",
+                    "default": false
+                }
+            },
+            "additionalProperties": false
+        }
+    }
+}


### PR DESCRIPTION
This is a set of classes that will generate automatic documentation for CRUDs.

I'm not really happy with this implementation and I am open to suggestions.

Here is what it does: it adds a decorator to the basic documentation factory that looks in routing for CRUD controllers. For each CRUD controller, it adds a new documentation entry.

@Valouleloup @mcsky WDYT?