### PR TITLE
Fix OkContent Normalizer

### DIFF
--- a/src/Response/Listener/SerializeOnKernelView.php
+++ b/src/Response/Listener/SerializeOnKernelView.php
@@ -40,6 +40,13 @@ class SerializeOnKernelView implements EventSubscriberInterface
             return;
         }
 
-        $event->setResponse(new JsonResponse($this->serializer->serialize($response, 'json'), $response->httpStatus(), [], true));
+        $event->setResponse(
+            new JsonResponse(
+                $this->serializer->serialize($response, 'json'),
+                $response->httpStatus(),
+                [],
+                true
+            )
+        );
     }
 }

--- a/src/Serialization/Json/OkContentNormalizer.php
+++ b/src/Serialization/Json/OkContentNormalizer.php
@@ -26,7 +26,7 @@ class OkContentNormalizer implements NormalizerInterface
      * @param string    $format
      * @param array     $context
      *
-     * @return array|bool|float|int|string|void
+     * @return array|bool|float|int|string
      */
     public function normalize($object, $format = null, array $context = array())
     {
@@ -35,7 +35,9 @@ class OkContentNormalizer implements NormalizerInterface
             $groups = array_merge($context['groups'], $groups);
         }
 
-        $context['groups'] = $groups;
+        if (!empty($groups)) {
+            $context['groups'] = $groups;
+        }
 
         return $this->decorated->normalize($object->getContent(), $format, $context);
     }

--- a/tests/Melodiia/Serialization/Json/OkContentNormalizerTest.php
+++ b/tests/Melodiia/Serialization/Json/OkContentNormalizerTest.php
@@ -40,6 +40,17 @@ class OkContentNormalizerTest extends TestCase
         $this->assertEquals('foo normalized', $res);
     }
 
+    public function testItDoesNotEnforceEmptyGroupArray()
+    {
+        $okContent = new OkContent('foo');
+
+        $this->mainNormalizer->normalize('foo', 'json', [])->willReturn('foo normalized')->shouldBeCalled();
+
+        $res = $this->okContentNormalizer->normalize($okContent, 'json');
+
+        $this->assertEquals('foo normalized', $res);
+    }
+
     public function testItSupportsOnlyOkContentInstance()
     {
         $this->assertTrue($this->okContentNormalizer->supportsNormalization(new OkContent('foo')));


### PR DESCRIPTION
It was adding a group section for every response which is wrong because empty group section cancel Symfony "Default" group behavior.