### PR TITLE
Add authorization checker feature to get crud

### DIFF
--- a/src/Bridge/Symfony/DependencyInjection/MelodiiaExtension.php
+++ b/src/Bridge/Symfony/DependencyInjection/MelodiiaExtension.php
@@ -46,7 +46,6 @@ class MelodiiaExtension extends Extension
                 $apiConf['paths'][] = $defaultPath;
             }
 
-
             // Register documentation factory
             $openApiFactory = new Definition(OpenApiDocFactory::class);
             $openApiFactory->setAutowired(true);

--- a/src/Bridge/Symfony/Resources/config/crud.yaml
+++ b/src/Bridge/Symfony/Resources/config/crud.yaml
@@ -16,4 +16,5 @@ services:
         class: Biig\Melodiia\Crud\Controller\Get
         arguments:
             $dataStore: '@melodiia.doctrine.data_provider'
+            $checker: '@security.authorization_checker'
         tags: [ controller.service_arguments ]

--- a/src/Bridge/Symfony/Routing/CrudDocumentationFactory.php
+++ b/src/Bridge/Symfony/Routing/CrudDocumentationFactory.php
@@ -7,8 +7,6 @@ use Biig\Melodiia\Documentation\DocumentationFactoryInterface;
 use Nekland\Tools\StringTools;
 use OpenApi\Analysis;
 use OpenApi\Annotations\Get;
-use OpenApi\Annotations\JsonContent;
-use OpenApi\Annotations\MediaType;
 use OpenApi\Annotations\Parameter;
 use OpenApi\Annotations\Post;
 use OpenApi\Annotations\Response;
@@ -17,7 +15,7 @@ use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\Router;
 
 /**
- * Class CrudDocumentationFactory
+ * Class CrudDocumentationFactory.
  *
  * Feel free to extends and redefine some of the methods of the
  */
@@ -58,10 +56,10 @@ class CrudDocumentationFactory implements DocumentationFactoryInterface
                 continue;
             }
 
-            if ($controller === 'melodiia.crud.controller.get') {
+            if ('melodiia.crud.controller.get' === $controller) {
                 $analysis->addAnnotation($this->createDocForGet($route), null);
             }
-            if ($controller === 'melodiia.crud.controller.create') {
+            if ('melodiia.crud.controller.create' === $controller) {
                 $analysis->addAnnotation($this->createDocForCreate($route), null);
             }
         }
@@ -89,7 +87,7 @@ class CrudDocumentationFactory implements DocumentationFactoryInterface
                 new Response([
                     'response' => 404,
                     'description' => 'Resource doesn\'t exist.',
-                ])
+                ]),
             ],
             'operationId' => $model . ':get',
             'parameters' => [
@@ -101,13 +99,13 @@ class CrudDocumentationFactory implements DocumentationFactoryInterface
                     'ref' => '#ref/components/schemas/Id',
                     'schema' => new Schema([
                         'type' => 'string',
-                        'schema' => 'id'
-                    ])
-                ])
+                        'schema' => 'id',
+                    ]),
+                ]),
             ],
             'summary' => $defaults[self::DOCUMENTATION_SUMMARY] ?? 'Return a resource',
             'description' => $defaults[self::DOCUMENTATION_DESCRIPTION] ?? 'Return the ressource based on given id',
-            'tags' => [$tag]
+            'tags' => [$tag],
         ]);
 
         return $annot;
@@ -128,7 +126,7 @@ class CrudDocumentationFactory implements DocumentationFactoryInterface
             'responses' => [
                 new Response([
                     'response' => 201,
-                    'description' => 'Resource created.'
+                    'description' => 'Resource created.',
                 ]),
                 new Response([
                     'response' => 400,
@@ -138,7 +136,7 @@ class CrudDocumentationFactory implements DocumentationFactoryInterface
             'operationId' => $model . ':post',
             'summary' => $defaults[self::DOCUMENTATION_SUMMARY] ?? 'Create a resource',
             'description' => $defaults[self::DOCUMENTATION_DESCRIPTION] ?? 'Return the id of the created resource',
-            'tags' => [$tag]
+            'tags' => [$tag],
         ]);
 
         return $annot;
@@ -161,7 +159,7 @@ class CrudDocumentationFactory implements DocumentationFactoryInterface
     {
         return [
             'melodiia.crud.controller.create',
-            'melodiia.crud.controller.get'
+            'melodiia.crud.controller.get',
         ];
     }
 }

--- a/src/Crud/Controller/Get.php
+++ b/src/Crud/Controller/Get.php
@@ -8,23 +8,34 @@ use Biig\Melodiia\Response\ApiResponse;
 use Biig\Melodiia\Response\NotFound;
 use Biig\Melodiia\Response\OkContent;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
 final class Get implements CrudControllerInterface
 {
     /** @var DataStoreInterface */
     private $dataStore;
 
-    public function __construct(DataStoreInterface $dataStore)
+    /** @var AuthorizationCheckerInterface */
+    private $checker;
+
+    public function __construct(DataStoreInterface $dataStore, AuthorizationCheckerInterface $checker)
     {
         $this->dataStore = $dataStore;
+        $this->checker = $checker;
     }
 
     public function __invoke(Request $request, $id): ApiResponse
     {
         $modelClass = $request->attributes->get(self::MODEL_ATTRIBUTE);
         $groups = $request->attributes->get(self::SERIALIZATION_GROUP, []);
+        $securityCheck = $request->attributes->get(self::SECURITY_CHECK, null);
 
         $data = $this->dataStore->find($modelClass, $id);
+
+        if ($securityCheck && !$this->checker->isGranted($securityCheck, $data)) {
+            throw new AccessDeniedException(\sprintf('Access denied to data of type "%s".', get_class($data)));
+        }
 
         if (null === $data) {
             return new NotFound();

--- a/src/Crud/CrudControllerInterface.php
+++ b/src/Crud/CrudControllerInterface.php
@@ -7,4 +7,5 @@ interface CrudControllerInterface
     public const MODEL_ATTRIBUTE = 'melodiia_model';
     public const FORM_ATTRIBUTE = 'melodiia_form';
     public const SERIALIZATION_GROUP = 'melodiia_serialization_group';
+    public const SECURITY_CHECK = 'melodiia_security_check';
 }

--- a/src/Documentation/OpenApiDocFactory.php
+++ b/src/Documentation/OpenApiDocFactory.php
@@ -21,7 +21,6 @@ final class OpenApiDocFactory implements DocumentationFactoryInterface
     /** @var array */
     private $config;
 
-
     public function __construct(RequestStack $requestStack, array $config)
     {
         $this->requestStack = $requestStack;

--- a/tests/Melodiia/Bridge/Symfony/Routing/CrudDocumentationFactoryTest.php
+++ b/tests/Melodiia/Bridge/Symfony/Routing/CrudDocumentationFactoryTest.php
@@ -7,7 +7,6 @@ use Biig\Melodiia\Crud\CrudControllerInterface;
 use Biig\Melodiia\Documentation\Controller\OpenApiJsonController;
 use Biig\Melodiia\Documentation\DocumentationFactoryInterface;
 use Biig\Melodiia\Documentation\OpenApiDocFactory;
-use GuzzleHttp\Client;
 use Nekland\Utils\Tempfile\TemporaryDirectory;
 use OpenApi\Analysis;
 use PHPUnit\Framework\TestCase;
@@ -100,10 +99,10 @@ class CrudDocumentationFactoryTest extends TestCase
 
         // OpenApi format check
         $json = json_decode($json);
-        $validator = new \JsonSchema\Validator;
+        $validator = new \JsonSchema\Validator();
         $validator->validate(
             $json,
-            (object)['$ref' => 'file://' . realpath(__DIR__ . '/../../../../openapi3-schema.json')]
+            (object) ['$ref' => 'file://' . realpath(__DIR__ . '/../../../../openapi3-schema.json')]
         );
         // Get errors with $validator->getErrors()
         $this->assertTrue($validator->isValid());
@@ -116,7 +115,7 @@ class CrudDocumentationFactoryTest extends TestCase
         $route = new Route('/foo', [
             CrudDocumentationFactory::DOCUMENTATION_DISABLED => true,
             '_controller' => 'melodiia.crud.controller.get',
-            CrudControllerInterface::MODEL_ATTRIBUTE => FakeModel::class]
+            CrudControllerInterface::MODEL_ATTRIBUTE => FakeModel::class, ]
         );
         $routeCollection = new RouteCollection();
         $routeCollection->add('foo', $route);
@@ -130,8 +129,8 @@ class CrudDocumentationFactoryTest extends TestCase
     }
 }
 
-
-class FakeModel {
+class FakeModel
+{
     private $foo;
 
     /**
@@ -159,5 +158,4 @@ class FakeModel {
     {
         $this->foo = $foo;
     }
-
 }


### PR DESCRIPTION
You can now define a crud controller this way in routing:

```yaml
get_awesome_result:
    controller: 'melodiia.crud.controller.get'
    path: '/api/v1/foo/{id}'
    methods: ['GET']
    defaults:
        melodiia_model: 'My\Entity'
        melodiia_serialization_group: 'some_group'
        documentation_disabled: true
        melodiia_security_check: 'view'
```