### PR TITLE
Add Update & GetAll crud controllers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,8 @@
         "zircote/swagger-php": "^3.0",
         "nekland/tools": "^2.0",
         "zendframework/zend-json": "^3.0",
-        "symfony/event-dispatcher": "^4.0"
+        "symfony/event-dispatcher": "^4.0",
+        "pagerfanta/pagerfanta": "^2.0.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.4",

--- a/src/Bridge/Doctrine/DoctrineDataStore.php
+++ b/src/Bridge/Doctrine/DoctrineDataStore.php
@@ -3,26 +3,56 @@
 namespace Biig\Melodiia\Bridge\Doctrine;
 
 use Biig\Melodiia\Crud\Persistence\DataStoreInterface;
+use Biig\Melodiia\Exception\ImpossibleToPaginateWithDoctrineRepository;
 use Doctrine\ORM\EntityManagerInterface;
+use Pagerfanta\Adapter\DoctrineORMAdapter;
+use Pagerfanta\Pagerfanta;
+use Doctrine\Common\Persistence\ManagerRegistry;
 
 class DoctrineDataStore implements DataStoreInterface
 {
-    /** @var EntityManagerInterface */
-    private $entityManager;
+    /** @var ManagerRegistry */
+    private $doctrineRegistry;
 
-    public function __construct(EntityManagerInterface $entityManager)
+    public function __construct(ManagerRegistry $registry)
     {
-        $this->entityManager = $entityManager;
+        $this->doctrineRegistry = $registry;
     }
 
     public function save(object $model)
     {
-        $this->entityManager->persist($model);
-        $this->entityManager->flush($model);
+        $this->getEntityManager()->persist($model);
+        $this->getEntityManager()->flush($model);
     }
 
     public function find(string $type, $id): ?object
     {
-        return $this->entityManager->getRepository($type)->find($id);
+        return $this->getEntityManager()->getRepository($type)->find($id);
+    }
+
+    public function getPaginated(string $type, int $page, $maxPerPage = 30, array $filters = []): PagerFanta
+    {
+        $doctrineRepository = $this->getEntityManager()->getRepository($type);
+
+        if (!method_exists($doctrineRepository, 'createQueryBuilder')) {
+            throw new ImpossibleToPaginateWithDoctrineRepository('Data cannot be paginated because your repository can\'t give a Doctrine query builder, please define method createQueryBuilder.');
+        }
+
+        $qb = $doctrineRepository->createQueryBuilder('item');
+
+        foreach ($filters as $filter) {
+            $filter->filter($qb);
+        }
+
+        $pager = new Pagerfanta(new DoctrineORMAdapter($qb));
+        $pager->setCurrentPage($page);
+        $pager->setMaxPerPage($maxPerPage);
+
+        return $pager;
+    }
+
+    protected function getEntityManager(): EntityManagerInterface
+    {
+        return $this->doctrineRegistry->getManager();
     }
 }

--- a/src/Bridge/Symfony/Form/DomainObjectsDataMapper.php
+++ b/src/Bridge/Symfony/Form/DomainObjectsDataMapper.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Biig\Melodiia\Bridge\Symfony\Form;
+
+use Symfony\Component\Form\DataMapperInterface;
+use Symfony\Component\Form\Extension\Core\DataMapper\PropertyPathMapper;
+use Symfony\Component\Form\FormInterface;
+
+/**
+ * Add support for objects that require constructor instantiation.
+ */
+class DomainObjectsDataMapper extends PropertyPathMapper implements DataMapperInterface
+{
+    public function mapFormsToData($forms, &$data)
+    {
+        $data = $this->createObject($forms, !empty($data) && is_object($data) ? get_class($data) : null);
+        parent::mapFormsToData($forms, $data);
+    }
+
+    /**
+     * @param FormInterface[] $form
+     * @param string          $dataClass
+     * @return null|object
+     * @throws \ReflectionException
+     */
+    public function createObject(iterable $form, string $dataClass = null)
+    {
+        if ($dataClass === null && $form instanceof FormInterface) {
+            $dataClass = $form->getConfig()->getOption('data_class');
+        }
+
+        $form = iterator_to_array($form);
+
+        if ($dataClass === null || !class_exists($dataClass)) {
+            return null;
+        }
+
+        $ref = new \ReflectionClass($dataClass);
+        $constructorParameters = $ref->getConstructor()->getParameters();
+
+        // Case of anemic object, we have nothing to do here.
+        if (count($constructorParameters) < 1) {
+            return new $dataClass();
+        }
+
+        $constructorData = [];
+        foreach ($constructorParameters as $parameter) {
+            if (isset($form[$parameter->getName()])) {
+                if (null === $form[$parameter->getName()]->getData() && !$parameter->allowsNull() && !$parameter->isDefaultValueAvailable()) {
+                    return null;
+                }
+
+                $data = $form[$parameter->getName()]->getData();
+            } else {
+                $data = null;
+            }
+
+            if (empty($data) && $parameter->isDefaultValueAvailable()) {
+                $data = $parameter->getDefaultValue();
+            }
+
+            $constructorData[] = $data;
+        }
+
+        return new $dataClass(...$constructorData);
+    }
+}

--- a/src/Bridge/Symfony/Form/Type/ApiType.php
+++ b/src/Bridge/Symfony/Form/Type/ApiType.php
@@ -2,16 +2,35 @@
 
 namespace Biig\Melodiia\Bridge\Symfony\Form\Type;
 
+use Biig\Melodiia\Bridge\Symfony\Form\DomainObjectsDataMapper;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\DataMapperInterface;
+use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class ApiType extends AbstractType
 {
+    /** @var DataMapperInterface */
+    private $dataMapper;
+
+    public function __construct(DataMapperInterface $dataMapper = null)
+    {
+        $this->dataMapper = $dataMapper ?? new DomainObjectsDataMapper();
+    }
+
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        if ($options['value_object']) {
+            $builder->setDataMapper($this->dataMapper);
+        }
+    }
+
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
             'csrf_protection' => false,
+            'value_object' => false,
 
             /*
              * Creates data object just like standard form would do
@@ -22,40 +41,7 @@ class ApiType extends AbstractType
              * @throws \ReflectionException
              */
             'empty_data' => function (FormInterface $form) {
-                $dataClass = $form->getConfig()->getOption('data_class');
-
-                if (!class_exists($dataClass)) {
-                    return null;
-                }
-
-                $ref = new \ReflectionClass($dataClass);
-                $constructorParameters = $ref->getConstructor()->getParameters();
-
-                // Case of anemic model, we have nothing to do here.
-                if (count($constructorParameters) < 1) {
-                    return new $dataClass();
-                }
-
-                $constructorData = [];
-                foreach ($constructorParameters as $parameter) {
-                    if ($form->has($parameter->getName())) {
-                        if (null === $form->get($parameter->getName())->getData() && !$parameter->allowsNull() && !$parameter->isDefaultValueAvailable()) {
-                            return null;
-                        }
-
-                        $data = $form->get($parameter->getName())->getData();
-                    } else {
-                        $data = null;
-                    }
-
-                    if (empty($data) && $parameter->isDefaultValueAvailable()) {
-                        $data = $parameter->getDefaultValue();
-                    }
-
-                    $constructorData[] = $data;
-                }
-
-                return new $dataClass(...$constructorData);
+                return $this->dataMapper->createObject($form);
             },
         ]);
     }

--- a/src/Bridge/Symfony/Resources/config/crud.yaml
+++ b/src/Bridge/Symfony/Resources/config/crud.yaml
@@ -2,7 +2,7 @@ services:
     melodiia.doctrine.data_provider:
         class: Biig\Melodiia\Bridge\Doctrine\DoctrineDataStore
         arguments:
-            $entityManager: '@doctrine.orm.entity_manager'
+            $registry: '@doctrine'
 
     melodiia.crud.controller.create:
         class: Biig\Melodiia\Crud\Controller\Create
@@ -10,6 +10,23 @@ services:
             $dataStore: '@melodiia.doctrine.data_provider'
             $formFactory: '@form.factory'
             $dispatcher: '@event_dispatcher'
+            $checker: '@security.authorization_checker'
+        tags: [ controller.service_arguments ]
+
+    melodiia.crud.controller.update:
+        class: Biig\Melodiia\Crud\Controller\Update
+        arguments:
+            $dataStore: '@melodiia.doctrine.data_provider'
+            $formFactory: '@form.factory'
+            $dispatcher: '@event_dispatcher'
+            $checker: '@security.authorization_checker'
+        tags: [ controller.service_arguments ]
+
+    melodiia.crud.controller.get_all:
+        class: Biig\Melodiia\Crud\Controller\GetAll
+        arguments:
+            $dataStore: '@melodiia.doctrine.data_provider'
+            $checker: '@security.authorization_checker'
         tags: [ controller.service_arguments ]
 
     melodiia.crud.controller.get:

--- a/src/Bridge/Symfony/Resources/config/services.yaml
+++ b/src/Bridge/Symfony/Resources/config/services.yaml
@@ -25,6 +25,7 @@ services:
         class: Biig\Melodiia\Serialization\Json\OkContentNormalizer
         arguments:
             $normalizer: '@serializer.normalizer.object'
+            $requestStack: '@request_stack'
         tags: [{ name: 'serializer.normalizer', priority: -1 }]
 
     Biig\Melodiia\MelodiiaConfigurationInterface: '@melodiia.configuration'

--- a/src/Bridge/Symfony/Resources/config/services.yaml
+++ b/src/Bridge/Symfony/Resources/config/services.yaml
@@ -23,8 +23,8 @@ services:
 
     melodiia.serialization.ok_content_normalizer:
         class: Biig\Melodiia\Serialization\Json\OkContentNormalizer
+        autoconfigure: true
         arguments:
-            $normalizer: '@serializer.normalizer.object'
             $requestStack: '@request_stack'
         tags: [{ name: 'serializer.normalizer', priority: -1 }]
 

--- a/src/Crud/Controller/GetAll.php
+++ b/src/Crud/Controller/GetAll.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Biig\Melodiia\Crud\Controller;
+
+use Biig\Melodiia\Crud\CrudableModelInterface;
+use Biig\Melodiia\Crud\CrudControllerInterface;
+use Biig\Melodiia\Crud\FilterInterface;
+use Biig\Melodiia\Crud\Persistence\DataStoreInterface;
+use Biig\Melodiia\Exception\MelodiiaLogicException;
+use Biig\Melodiia\Response\OkContent;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+
+class GetAll implements CrudControllerInterface
+{
+    /** @var DataStoreInterface */
+    private $dataStore;
+
+    /** @var AuthorizationCheckerInterface */
+    private $checker;
+
+    /** @var FilterInterface */
+    private $filters;
+
+    public function __construct(DataStoreInterface $dataStore, AuthorizationCheckerInterface $checker, array $filters = [])
+    {
+        $this->dataStore = $dataStore;
+        $this->checker = $checker;
+        $this->filters = $filters;
+    }
+
+    public function __invoke(Request $request)
+    {
+        // Metadata you can specify in routing definition
+        $modelClass = $request->attributes->get(self::MODEL_ATTRIBUTE);
+        $securityCheck = $request->attributes->get(self::SECURITY_CHECK, null);
+        $groups = $request->attributes->get(self::SERIALIZATION_GROUP, []);
+
+        if (empty($modelClass) || !class_exists($modelClass) || !is_subclass_of($modelClass, CrudableModelInterface::class)) {
+            throw new MelodiiaLogicException('If you use melodiia CRUD classes, you need to specify a model.');
+        }
+
+        if ($securityCheck && !$this->checker->isGranted($securityCheck)) {
+            throw new AccessDeniedException(\sprintf('Access denied to data of type "%s".', $modelClass));
+        }
+
+        $page = $request->query->getInt('page', 1);
+        $maxPerPage = $request->attributes->get(self::MAX_PER_PAGE_ATTRIBUTE, 30);
+
+        $items = $this->dataStore->getPaginated($modelClass, $page, $maxPerPage, $this->filters);
+
+        return new OkContent($items, $groups);
+    }
+}

--- a/src/Crud/Controller/Update.php
+++ b/src/Crud/Controller/Update.php
@@ -11,6 +11,7 @@ use Biig\Melodiia\Crud\Persistence\DataStoreInterface;
 use Biig\Melodiia\Exception\MelodiiaLogicException;
 use Biig\Melodiia\Response\ApiResponse;
 use Biig\Melodiia\Response\Ok;
+use Biig\Melodiia\Response\OkContent;
 use Biig\Melodiia\Response\WrongDataInput;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\FormFactoryInterface;
@@ -89,6 +90,6 @@ final class Update implements CrudControllerInterface
             return $event->getResponse();
         }
 
-        return new Ok($data->getId());
+        return new OkContent(['id' => $data->getId()]);
     }
 }

--- a/src/Crud/Controller/Update.php
+++ b/src/Crud/Controller/Update.php
@@ -71,7 +71,7 @@ final class Update implements CrudControllerInterface
 
         $form = $this->formFactory->createNamed('', $form, $data);
         $inputData = Json::decode($request->getContent(), Json::TYPE_ARRAY);
-        $form->submit($inputData);
+        $form->submit($inputData, false);
 
         if (!$form->isSubmitted()) {
             return new WrongDataInput();

--- a/src/Crud/CrudControllerInterface.php
+++ b/src/Crud/CrudControllerInterface.php
@@ -8,4 +8,5 @@ interface CrudControllerInterface
     public const FORM_ATTRIBUTE = 'melodiia_form';
     public const SERIALIZATION_GROUP = 'melodiia_serialization_group';
     public const SECURITY_CHECK = 'melodiia_security_check';
+    public const MAX_PER_PAGE_ATTRIBUTE = 'melodiia_max_per_page';
 }

--- a/src/Crud/Event/CustomResponseEvent.php
+++ b/src/Crud/Event/CustomResponseEvent.php
@@ -2,6 +2,8 @@
 
 namespace Biig\Melodiia\Crud\Event;
 
+use Biig\Melodiia\Response\ApiResponse;
+
 class CustomResponseEvent extends CrudEvent
 {
     /** @var ApiResponse|null */
@@ -12,7 +14,7 @@ class CustomResponseEvent extends CrudEvent
         $this->response = $response;
     }
 
-    public function getResponse(): ApiResponse
+    public function getResponse(): ?ApiResponse
     {
         return $this->response;
     }

--- a/src/Crud/FilterInterface.php
+++ b/src/Crud/FilterInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Biig\Melodiia\Crud;
+
+interface FilterInterface
+{
+    public function filter($query);
+}

--- a/src/Crud/Persistence/DataStoreInterface.php
+++ b/src/Crud/Persistence/DataStoreInterface.php
@@ -2,9 +2,26 @@
 
 namespace Biig\Melodiia\Crud\Persistence;
 
+use Biig\Melodiia\Crud\FilterInterface;
+use Pagerfanta\Pagerfanta;
+
 interface DataStoreInterface
 {
     public function save(object $model);
 
+    /**
+     * @param string     $type
+     * @param string|int $id
+     * @return null|object
+     */
     public function find(string $type, $id): ?object;
+
+    /**
+     * @param string             $type
+     * @param int                $page
+     * @param int                $maxPerPage
+     * @param FilterInterface[]  $filters
+     * @return Pagerfanta
+     */
+    public function getPaginated(string $type, int $page, $maxPerPage = 30, array $filters = []): PagerFanta;
 }

--- a/src/Exception/ImpossibleToPaginateWithDoctrineRepository.php
+++ b/src/Exception/ImpossibleToPaginateWithDoctrineRepository.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Biig\Melodiia\Exception;
+
+class ImpossibleToPaginateWithDoctrineRepository extends MelodiiaLogicException
+{
+}

--- a/src/Response/OkContent.php
+++ b/src/Response/OkContent.php
@@ -25,6 +25,11 @@ class OkContent implements ApiResponse, SerializationContextAwareInterface
         return $this->content;
     }
 
+    public function isCollection(): bool
+    {
+        return !is_array($this->content) && is_iterable($this->content);
+    }
+
     public function httpStatus(): int
     {
         return 200;

--- a/src/Serialization/Json/OkContentNormalizer.php
+++ b/src/Serialization/Json/OkContentNormalizer.php
@@ -59,8 +59,8 @@ class OkContentNormalizer implements NormalizerInterface
         if ($content instanceof Pagerfanta) {
             $result['meta'] = ['totalPages' => $content->getNbPages()];
             $uri = $this->requestStack->getMasterRequest()->getUri();
-            $previousPage = $uri;
-            $nextPage = $uri;
+            $previousPage = null;
+            $nextPage = null;
 
             if ($content->hasPreviousPage()) {
                 $previousPage = \preg_replace('/([?&])page=(\d+)/', '$1page=' . $content->getPreviousPage(), $uri);

--- a/src/Serialization/Json/OkContentNormalizer.php
+++ b/src/Serialization/Json/OkContentNormalizer.php
@@ -7,6 +7,9 @@ use Pagerfanta\Pagerfanta;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\Generator\UrlGenerator;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\Component\Serializer\SerializerAwareInterface;
+use Symfony\Component\Serializer\SerializerAwareTrait;
+use Symfony\Component\Serializer\SerializerInterface;
 
 /**
  * Class OkContentNormalizer.
@@ -14,17 +17,15 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
  * Normalize only the content of OkContent object using the serialization
  * context contained in OkContent object.
  */
-class OkContentNormalizer implements NormalizerInterface
+class OkContentNormalizer implements NormalizerInterface, SerializerAwareInterface
 {
-    /** @var NormalizerInterface */
-    private $decorated;
+    use SerializerAwareTrait;
 
     /** @var RequestStack */
     private $requestStack;
 
-    public function __construct(NormalizerInterface $normalizer, RequestStack $requestStack)
+    public function __construct(RequestStack $requestStack)
     {
-        $this->decorated = $normalizer;
         $this->requestStack = $requestStack;
     }
 
@@ -48,7 +49,7 @@ class OkContentNormalizer implements NormalizerInterface
 
         // Simple object case
         if (!$object->isCollection()) {
-            return $this->decorated->normalize($object->getContent(), $format, $context);
+            return $this->serializer->normalize($object->getContent(), $format, $context);
         }
 
         // Collection case
@@ -79,7 +80,7 @@ class OkContentNormalizer implements NormalizerInterface
 
         $result['data'] = [];
         foreach ($content as $item) {
-            $result['data'][] = $this->decorated->normalize($item, $format, $context);
+            $result['data'][] = $this->serializer->normalize($item, $format, $context);
         }
 
         return $result;

--- a/tests/Melodiia/Bridge/Doctrine/DoctrineDataStoreTest.php
+++ b/tests/Melodiia/Bridge/Doctrine/DoctrineDataStoreTest.php
@@ -3,10 +3,15 @@
 namespace Biig\Melodiia\Test\Bridge\Doctrine;
 
 use Biig\Melodiia\Bridge\Doctrine\DoctrineDataStore;
+use Biig\Melodiia\Crud\FilterInterface;
 use Biig\Melodiia\Crud\Persistence\DataStoreInterface;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\EntityRepository;
+use Doctrine\ORM\QueryBuilder;
+use Pagerfanta\Pagerfanta;
 use PHPUnit\Framework\TestCase;
 use Doctrine\Common\Persistence\ManagerRegistry;
+use Prophecy\Argument;
 
 class DoctrineDataStoreTest extends TestCase
 {
@@ -28,5 +33,23 @@ class DoctrineDataStoreTest extends TestCase
 
         $datastore = new DoctrineDataStore($managerRegistry->reveal());
         $datastore->save($obj);
+    }
+
+    public function testItPaginate()
+    {
+        $qb = $this->prophesize(QueryBuilder::class)->reveal();
+        $repo = $this->prophesize(EntityRepository::class);
+        $repo->createQueryBuilder(Argument::any())->willReturn($qb);
+        $manager = $this->prophesize(EntityManagerInterface::class);
+        $manager->getRepository(Argument::any())->willReturn($repo->reveal());
+        $registry = $this->prophesize(ManagerRegistry::class);
+        $registry->getManager()->willReturn($manager->reveal());
+
+        $filter = $this->prophesize(FilterInterface::class);
+        $filter->filter($qb)->shouldBeCalled();
+
+        $dataStore = new DoctrineDataStore($registry->reveal());
+        $pager = $dataStore->getPaginated('DummyEntity', 1, 30, [$filter->reveal()]);
+        $this->assertInstanceOf(Pagerfanta::class, $pager);
     }
 }

--- a/tests/Melodiia/Bridge/Doctrine/DoctrineDataStoreTest.php
+++ b/tests/Melodiia/Bridge/Doctrine/DoctrineDataStoreTest.php
@@ -6,12 +6,13 @@ use Biig\Melodiia\Bridge\Doctrine\DoctrineDataStore;
 use Biig\Melodiia\Crud\Persistence\DataStoreInterface;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\TestCase;
+use Doctrine\Common\Persistence\ManagerRegistry;
 
 class DoctrineDataStoreTest extends TestCase
 {
     public function testItIsAMelodiiaDataStore()
     {
-        $datastore = new DoctrineDataStore($this->prophesize(EntityManagerInterface::class)->reveal());
+        $datastore = new DoctrineDataStore($this->prophesize(ManagerRegistry::class)->reveal());
 
         $this->assertInstanceOf(DataStoreInterface::class, $datastore);
     }
@@ -22,8 +23,10 @@ class DoctrineDataStoreTest extends TestCase
         $entityManager = $this->prophesize(EntityManagerInterface::class);
         $entityManager->persist($obj)->shouldBeCalled();
         $entityManager->flush($obj)->shouldBeCalled();
+        $managerRegistry = $this->prophesize(ManagerRegistry::class);
+        $managerRegistry->getManager()->willReturn($entityManager->reveal());
 
-        $datastore = new DoctrineDataStore($entityManager->reveal());
+        $datastore = new DoctrineDataStore($managerRegistry->reveal());
         $datastore->save($obj);
     }
 }

--- a/tests/Melodiia/Bridge/Symfony/Form/ApiTypeTest.php
+++ b/tests/Melodiia/Bridge/Symfony/Form/ApiTypeTest.php
@@ -64,6 +64,6 @@ class FakeTypeUsingApiType extends \Biig\Melodiia\Bridge\Symfony\Form\AbstractTy
 
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefaults(['data_class' => FakeModel::class]);
+        $resolver->setDefaults(['data_class' => FakeModel::class, 'value_object' => true]);
     }
 }

--- a/tests/Melodiia/Bridge/Symfony/Form/DomainObjectsDataMapperTest.php
+++ b/tests/Melodiia/Bridge/Symfony/Form/DomainObjectsDataMapperTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Biig\Melodiia\Test\Bridge\Symfony\Form;
+
+
+use Biig\Melodiia\Bridge\Symfony\Form\DomainObjectsDataMapper;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Form\DataMapperInterface;
+use Symfony\Component\Form\Extension\Core\DataMapper\PropertyPathMapper;
+use Symfony\Component\Form\Form;
+use Symfony\Component\Form\FormConfigBuilder;
+
+class DomainObjectsDataMapperTest extends TestCase
+{
+    public function testItIsInstanceOfDataMapper()
+    {
+        $this->assertInstanceOf(DataMapperInterface::class, new DomainObjectsDataMapper());
+    }
+
+    public function testItExtendsPropertyPathDataMapper()
+    {
+        $this->assertInstanceOf(PropertyPathMapper::class, new DomainObjectsDataMapper());
+    }
+
+    public function testItBuildObjectFromForm()
+    {
+        $mapper = new DomainObjectsDataMapper();
+
+        $dispatcher = $this->prophesize(EventDispatcherInterface::class)->reveal();
+        $form1 = new Form((new FormConfigBuilder('hello', null, $dispatcher))->setData('world')->getFormConfig());
+        $form2 = new Form((new FormConfigBuilder('foo', null, $dispatcher))->setData('bar')->getFormConfig());
+
+        $form = new \ArrayIterator(['hello' => $form1, 'foo' => $form2]);
+
+        $obj = $mapper->createObject($form, FakeValueObject::class);
+        $this->assertInstanceOf(FakeValueObject::class, $obj);
+    }
+}
+
+class FakeValueObject
+{
+    private $hello;
+    private $foo;
+
+    /**
+     * FakeValueObject constructor.
+     * @param $hello
+     * @param $foo
+     */
+    public function __construct($hello, $foo)
+    {
+        $this->hello = $hello;
+        $this->foo = $foo;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getHello()
+    {
+        return $this->hello;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getFoo()
+    {
+        return $this->foo;
+    }
+}

--- a/tests/Melodiia/Crud/Controller/GetAllTest.php
+++ b/tests/Melodiia/Crud/Controller/GetAllTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Biig\Melodiia\Test\Crud\Controller;
+
+use Biig\Melodiia\Crud\Controller\GetAll;
+use Biig\Melodiia\Crud\CrudControllerInterface;
+use Biig\Melodiia\Crud\Persistence\DataStoreInterface;
+use Biig\Melodiia\Response\OkContent;
+use Biig\Melodiia\Test\TestFixtures\FakeMelodiiaModel;
+use Pagerfanta\Adapter\ArrayAdapter;
+use Pagerfanta\Pagerfanta;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
+use Symfony\Component\HttpFoundation\ParameterBag;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+
+class GetAllTest extends TestCase
+{
+    /** @var DataStoreInterface|ObjectProphecy */
+    private $dataStore;
+
+    /** @var AuthorizationCheckerInterface|ObjectProphecy */
+    private $authorizationChecker;
+
+    /** @var Request|ObjectProphecy */
+    private $request;
+
+    /** @var ParameterBag|ObjectProphecy */
+    private $attributes;
+
+    /** @var GetAll */
+    private $controller;
+
+    public function setUp()
+    {
+        $this->dataStore = $this->prophesize(DataStoreInterface::class);
+        $this->authorizationChecker = $this->prophesize(AuthorizationCheckerInterface::class);
+        $this->attributes = $this->prophesize(ParameterBag::class);
+        $this->attributes->get(CrudControllerInterface::MODEL_ATTRIBUTE)->willReturn(FakeMelodiiaModel::class);
+        $this->attributes->get(CrudControllerInterface::SERIALIZATION_GROUP, [])->willReturn([]);
+        $this->attributes->get(CrudControllerInterface::SECURITY_CHECK, null)->willReturn(null);
+        $this->attributes->get(CrudControllerInterface::MAX_PER_PAGE_ATTRIBUTE, 30)->willReturn(30);
+        $query = $this->prophesize(ParameterBag::class);
+        $query->getInt('page', Argument::cetera())->willReturn(1);
+        $this->request = $this->prophesize(Request::class);
+        $this->request->attributes = $this->attributes->reveal();
+        $this->request->query = $query->reveal();
+
+        $this->controller = new GetAll($this->dataStore->reveal(), $this->authorizationChecker->reveal());
+    }
+
+    public function testItIsIntanceOfMelodiiaController()
+    {
+        $this->assertInstanceOf(CrudControllerInterface::class, $this->controller);
+    }
+
+    public function testItReturnResourceFromDataStoreInsideOkContent()
+    {
+        $this->dataStore->getPaginated(FakeMelodiiaModel::class, Argument::cetera())->willReturn(new Pagerfanta(new ArrayAdapter([new \stdClass()])))->shouldBeCalled();
+
+        $res = ($this->controller)($this->request->reveal());
+
+        $this->assertInstanceOf(OkContent::class, $res);
+        $this->assertTrue($res->isCollection());
+        $this->assertIsIterable($res->getContent());
+    }
+
+    public function testItStillReturn200OkOnEmptyPaginated()
+    {
+        $this->dataStore->getPaginated(FakeMelodiiaModel::class, Argument::cetera())->willReturn(new Pagerfanta(new ArrayAdapter([])))->shouldBeCalled();
+
+        $res = ($this->controller)($this->request->reveal());
+
+        $this->assertInstanceOf(OkContent::class, $res);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Security\Core\Exception\AccessDeniedException
+     */
+    public function testItCheckAccessToResourceIfSpecifiedInConfiguration()
+    {
+        $this->attributes->get(CrudControllerInterface::SECURITY_CHECK, null)->willReturn('view');
+
+        $this->authorizationChecker->isGranted('view', Argument::any())->willReturn(false);
+
+        ($this->controller)($this->request->reveal(), 'id');
+    }
+}

--- a/tests/Melodiia/Crud/Controller/UpdateTest.php
+++ b/tests/Melodiia/Crud/Controller/UpdateTest.php
@@ -64,7 +64,7 @@ class UpdateTest extends TestCase
         $this->attributes->get(CrudControllerInterface::SECURITY_CHECK, null)->willReturn(null);
         $this->request->attributes = $this->attributes->reveal();
         $this->request->getContent()->willReturn('{"awesome":"json"}');
-        $this->form->submit(['awesome' => 'json'])->willReturn();
+        $this->form->submit(['awesome' => 'json'], false)->willReturn();
         $this->formFactory->createNamed('', Argument::cetera())->willReturn($this->form);
 
         $this->dataStore->find(FakeMelodiiaModel::class, 'id')->willReturn(new \stdClass());

--- a/tests/Melodiia/Crud/Controller/UpdateTest.php
+++ b/tests/Melodiia/Crud/Controller/UpdateTest.php
@@ -10,6 +10,7 @@ use Biig\Melodiia\Crud\Event\CustomResponseEvent;
 use Biig\Melodiia\Crud\Persistence\DataStoreInterface;
 use Biig\Melodiia\Response\ApiResponse;
 use Biig\Melodiia\Response\Ok;
+use Biig\Melodiia\Response\OkContent;
 use Biig\Melodiia\Test\TestFixtures\FakeMelodiiaFormType;
 use Biig\Melodiia\Test\TestFixtures\FakeMelodiiaModel;
 use PHPUnit\Framework\TestCase;
@@ -112,7 +113,7 @@ class UpdateTest extends TestCase
         /** @var ApiResponse $res */
         $res = ($this->controller)($this->request->reveal(), 'id');
 
-        $this->assertInstanceOf(Ok::class, $res);
+        $this->assertInstanceOf(OkContent::class, $res);
     }
 
     /**

--- a/tests/Melodiia/Crud/Controller/UpdateTest.php
+++ b/tests/Melodiia/Crud/Controller/UpdateTest.php
@@ -3,13 +3,13 @@
 namespace Biig\Melodiia\Test\Crud\Controller;
 
 use Biig\Melodiia\Bridge\Symfony\Response\FormErrorResponse;
-use Biig\Melodiia\Crud\Controller\Create;
+use Biig\Melodiia\Crud\Controller\Update;
 use Biig\Melodiia\Crud\CrudControllerInterface;
 use Biig\Melodiia\Crud\Event\CrudEvent;
 use Biig\Melodiia\Crud\Event\CustomResponseEvent;
 use Biig\Melodiia\Crud\Persistence\DataStoreInterface;
 use Biig\Melodiia\Response\ApiResponse;
-use Biig\Melodiia\Response\Created;
+use Biig\Melodiia\Response\Ok;
 use Biig\Melodiia\Test\TestFixtures\FakeMelodiiaFormType;
 use Biig\Melodiia\Test\TestFixtures\FakeMelodiiaModel;
 use PHPUnit\Framework\TestCase;
@@ -22,7 +22,7 @@ use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
-class CreateTest extends TestCase
+class UpdateTest extends TestCase
 {
     /** @var FormFactoryInterface|ObjectProphecy */
     private $formFactory;
@@ -45,7 +45,7 @@ class CreateTest extends TestCase
     /** @var AuthorizationCheckerInterface|ObjectProphecy */
     private $checker;
 
-    /** @var Create */
+    /** @var Update */
     private $controller;
 
     public function setUp()
@@ -66,7 +66,9 @@ class CreateTest extends TestCase
         $this->form->submit(['awesome' => 'json'])->willReturn();
         $this->formFactory->createNamed('', Argument::cetera())->willReturn($this->form);
 
-        $this->controller = new Create(
+        $this->dataStore->find(FakeMelodiiaModel::class, 'id')->willReturn(new \stdClass());
+
+        $this->controller = new Update(
             $this->dataStore->reveal(),
             $this->formFactory->reveal(),
             $this->dispatcher->reveal(),
@@ -79,7 +81,7 @@ class CreateTest extends TestCase
         $this->form->isSubmitted()->willReturn(false);
 
         /** @var ApiResponse $res */
-        $res = ($this->controller)($this->request->reveal());
+        $res = ($this->controller)($this->request->reveal(), 'id');
 
         $this->assertInstanceOf(ApiResponse::class, $res);
         $this->assertEquals(400, $res->httpStatus());
@@ -91,7 +93,7 @@ class CreateTest extends TestCase
         $this->form->isValid()->willReturn(false);
 
         /** @var ApiResponse $res */
-        $res = ($this->controller)($this->request->reveal());
+        $res = ($this->controller)($this->request->reveal(), 'id');
 
         $this->assertInstanceOf(FormErrorResponse::class, $res);
         $this->assertEquals(400, $res->httpStatus());
@@ -103,15 +105,14 @@ class CreateTest extends TestCase
         $this->form->isValid()->willReturn(true);
 
         $this->form->getData()->willReturn(new FakeMelodiiaModel());
-        $this->dispatcher->dispatch(Create::EVENT_PRE_CREATE, Argument::type(CrudEvent::class))->shouldBeCalled();
-        $this->dispatcher->dispatch(Create::EVENT_POST_CREATE, Argument::type(CustomResponseEvent::class))->shouldBeCalled();
+        $this->dispatcher->dispatch(Update::EVENT_PRE_UPDATE, Argument::type(CrudEvent::class))->shouldBeCalled();
+        $this->dispatcher->dispatch(Update::EVENT_POST_UPDATE, Argument::type(CustomResponseEvent::class))->shouldBeCalled();
         $this->dataStore->save(Argument::type(FakeMelodiiaModel::class))->shouldBeCalled();
 
         /** @var ApiResponse $res */
-        $res = ($this->controller)($this->request->reveal());
+        $res = ($this->controller)($this->request->reveal(), 'id');
 
-        $this->assertInstanceOf(Created::class, $res);
-        $this->assertEquals(201, $res->httpStatus());
+        $this->assertInstanceOf(Ok::class, $res);
     }
 
     /**
@@ -122,6 +123,6 @@ class CreateTest extends TestCase
         $this->attributes->get(CrudControllerInterface::SECURITY_CHECK, null)->willReturn('edit');
         $this->checker->isGranted(Argument::cetera())->willReturn(false);
 
-        ($this->controller)($this->request->reveal());
+        ($this->controller)($this->request->reveal(), 'id');
     }
 }

--- a/tests/Melodiia/Crud/Event/CustomResponseEventTest.php
+++ b/tests/Melodiia/Crud/Event/CustomResponseEventTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Biig\Melodiia\Test\Crud\Event;
+
+use Biig\Melodiia\Crud\Event\CrudEvent;
+use Biig\Melodiia\Crud\Event\CustomResponseEvent;
+use Biig\Melodiia\Response\ApiResponse;
+use PHPUnit\Framework\TestCase;
+
+class CustomResponseEventTest extends TestCase
+{
+    public function testItImplementsCrudEvent()
+    {
+        $event = new CustomResponseEvent(new \stdClass());
+        $this->assertInstanceOf(CrudEvent::class, $event);
+    }
+
+    public function testItReturnsNoResponseByDefault()
+    {
+        $event = new CustomResponseEvent(new \stdClass());
+        $this->assertFalse($event->hasCustomResponse());
+        $this->assertNull($event->getResponse());
+    }
+
+    public function testItReturnsResponseIfSpeficied()
+    {
+        $event = new CustomResponseEvent(new \stdClass());
+        $event->setResponse($response = $this->prophesize(ApiResponse::class)->reveal());
+        $this->assertTrue($event->hasCustomResponse());
+        $this->assertEquals($response, $event->getResponse());
+    }
+}

--- a/tests/Melodiia/Serialization/Json/OkContentNormalizerTest.php
+++ b/tests/Melodiia/Serialization/Json/OkContentNormalizerTest.php
@@ -4,9 +4,13 @@ namespace Biig\Melodiia\Test\Serialization\Json;
 
 use Biig\Melodiia\Response\OkContent;
 use Biig\Melodiia\Serialization\Json\OkContentNormalizer;
+use Pagerfanta\Adapter\ArrayAdapter;
+use Pagerfanta\Pagerfanta;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 class OkContentNormalizerTest extends TestCase
@@ -14,14 +18,23 @@ class OkContentNormalizerTest extends TestCase
     /** @var NormalizerInterface|ObjectProphecy */
     private $mainNormalizer;
 
+    /** @var RequestStack|ObjectProphecy */
+    private $requestStack;
+
+    /** @var Request|ObjectProphecy */
+    private $request;
+
     /** @var OkContentNormalizer */
     private $okContentNormalizer;
 
     public function setUp()
     {
         $this->mainNormalizer = $this->prophesize(NormalizerInterface::class);
+        $this->requestStack = $this->prophesize(RequestStack::class);
+        $this->request = $this->prophesize(Request::class);
+        $this->requestStack->getMasterRequest()->willReturn($this->request->reveal());
 
-        $this->okContentNormalizer = new OkContentNormalizer($this->mainNormalizer->reveal());
+        $this->okContentNormalizer = new OkContentNormalizer($this->mainNormalizer->reveal(), $this->requestStack->reveal());
     }
 
     public function testItIsInstanceOfNormalizerInterface()
@@ -67,5 +80,47 @@ class OkContentNormalizerTest extends TestCase
         $res = $this->okContentNormalizer->normalize($okContent);
 
         $this->assertEquals('foo normalized', $res);
+    }
+
+    public function testItSerializeArray()
+    {
+        $okContent = new OkContent(['foo']);
+
+        $this->mainNormalizer->normalize(['foo'], Argument::cetera())->willReturn('foo normalized')->shouldBeCalled();
+
+        $res = $this->okContentNormalizer->normalize($okContent);
+
+        $this->assertEquals('foo normalized', $res);
+    }
+
+    public function testItSerializePager()
+    {
+        $content = [
+            'foo', 'bar', 'baz', 'hello', 'world', 'more', 'content', 'yaya', 'yoyo', 'random', 'words'
+        ];
+        $pager = new Pagerfanta(new ArrayAdapter($content));
+        $pager->setMaxPerPage(4);
+        $pager->setCurrentPage(2);
+        $okContent = new OkContent($pager);
+        $this->request->getUri()->willReturn('http://foo.com/bar?page=2');
+
+        foreach (['world', 'more', 'content', 'yaya'] as $data) {
+            $this->mainNormalizer->normalize($data, Argument::cetera())->willReturn($data .' normalized')->shouldBeCalled();
+        }
+
+        $res = $this->okContentNormalizer->normalize($okContent);
+
+        $this->assertEquals([
+            'data' => [
+                'world normalized', 'more normalized', 'content normalized', 'yaya normalized'
+            ],
+            'meta' => ['totalPages' => 3],
+            'links' => [
+                'prev' => 'http://foo.com/bar?page=1',
+                'next' => 'http://foo.com/bar?page=3',
+                'last' => 'http://foo.com/bar?page=3',
+                'first' => 'http://foo.com/bar?page=1'
+            ]
+        ], $res);
     }
 }

--- a/tests/Melodiia/Serialization/Json/OkContentNormalizerTest.php
+++ b/tests/Melodiia/Serialization/Json/OkContentNormalizerTest.php
@@ -12,6 +12,7 @@ use Prophecy\Prophecy\ObjectProphecy;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\Component\Serializer\Serializer;
 
 class OkContentNormalizerTest extends TestCase
 {
@@ -29,12 +30,13 @@ class OkContentNormalizerTest extends TestCase
 
     public function setUp()
     {
-        $this->mainNormalizer = $this->prophesize(NormalizerInterface::class);
+        $this->mainNormalizer = $this->prophesize(Serializer::class);
         $this->requestStack = $this->prophesize(RequestStack::class);
         $this->request = $this->prophesize(Request::class);
         $this->requestStack->getMasterRequest()->willReturn($this->request->reveal());
 
-        $this->okContentNormalizer = new OkContentNormalizer($this->mainNormalizer->reveal(), $this->requestStack->reveal());
+        $this->okContentNormalizer = new OkContentNormalizer($this->requestStack->reveal());
+        $this->okContentNormalizer->setSerializer($this->mainNormalizer->reveal());
     }
 
     public function testItIsInstanceOfNormalizerInterface()

--- a/tests/Melodiia/TestFixtures/FakeMelodiiaFormType.php
+++ b/tests/Melodiia/TestFixtures/FakeMelodiiaFormType.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Biig\Melodiia\Test\TestFixtures;
+
+use Biig\Melodiia\Bridge\Symfony\Form\AbstractType;
+
+class FakeMelodiiaFormType extends AbstractType
+{
+
+}

--- a/tests/Melodiia/TestFixtures/FakeMelodiiaModel.php
+++ b/tests/Melodiia/TestFixtures/FakeMelodiiaModel.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Biig\Melodiia\Test\TestFixtures;
+
+use Biig\Melodiia\Crud\CrudableModelInterface;
+
+class FakeMelodiiaModel implements CrudableModelInterface
+{
+    public function getId()
+    {
+        return 1;
+    }
+}


### PR DESCRIPTION
This commit comes with some improvements:
- Security check is generalilzed
- Tests are improved
- CustomResponseEvent (luckily not used anywhere ATM) is fixed
- GetAll & Update controllers
- New features for dataprovider, which means BC Break, which means **version upgrade needed to 0.2**