### PR TITLE
Add a complete feature of filters for Melodiia

### DIFF
--- a/docs/Crud.md
+++ b/docs/Crud.md
@@ -1,0 +1,101 @@
+CRUDs with Melodiia
+===================
+
+Register your first CRUD
+------------------------
+
+Melodiia CRUDs are **simple** controllers that you can configure in the routing.
+
+For any further usage, consider using your own controller.
+
+Here is an example of configuration:
+
+```yaml
+acme_article_create:
+    path: /api/v1/articles
+    controller: 'melodiia.crud.controller.create'
+    methods: ['POST']
+    defaults:
+        melodiia_model: App\Entity\Article
+        melodiia_form: App\Form\ArticleType
+
+acme_article_update:
+    path: /api/v1/articles/{id}
+    controller: 'melodiia.crud.controller.update'
+    methods: ['PATCH']
+    defaults:
+        melodiia_model: App\Entity\Article
+        melodiia_form: App\Form\ArticleType
+
+
+acme_article_get_collection:
+    path: /api/v1/articles
+    controller: 'melodiia.crud.controller.get_all'
+    methods: ['GET']
+    defaults:
+        melodiia_model: App\Entity\Article
+        melodiia_serialization_group: "list-article"
+
+acme_article_get:
+    path: /api/v1/articles/{id}
+    controller: 'melodiia.crud.controller.get'
+    methods: ['GET']
+    defaults:
+        melodiia_model: App\Entity\Article
+```
+
+Learn more about available options in `CrudControllerInterface`.
+
+Filters
+-------
+
+Filters are enabled for `GetAll` controllers. You can use them by yourself
+if you consider using the `FilterCollectionFactory`.
+
+All you have to do is to implement the interface `FilterInterface`.
+
+Currently Doctrine query is the only type of query managed by the filters.
+
+Here is an example of filter you may want to do:
+
+```php
+<?php
+// TypeFilter
+
+class TypeFilter implements \Biig\Melodiia\Crud\FilterInterface
+{
+    /** @var string[] */
+    private $types;
+
+    public function __construct(array $types)
+    {
+        $this->types = $types;
+    }
+
+    public function filter(QueryBuilder $query, FormInterface $form): void
+    {
+        $type = $form->get('type')->getData();
+        if ($type !== null) {
+            $query
+                ->andWhere($query->expr()->eq('item.type', ':filterType'))
+                ->setParameter('filterType', $type)
+            ;
+        }
+    }
+
+    public function supports(string $class): bool
+    {
+        return $class === MyEntity::class;
+    }
+
+    public function buildForm(FormBuilderInterface $formBuilder): void
+    {
+        $formBuilder->add('type', ChoiceType::class, [
+            'choices' => $this->types            
+        ]); 
+    }
+}
+
+```
+
+> Note: the given query builder name the entity `item` no matter what kind of entity it is.

--- a/src/Bridge/Doctrine/DoctrineDataStore.php
+++ b/src/Bridge/Doctrine/DoctrineDataStore.php
@@ -2,12 +2,13 @@
 
 namespace Biig\Melodiia\Bridge\Doctrine;
 
+use Biig\Melodiia\Crud\FilterCollection;
 use Biig\Melodiia\Crud\Persistence\DataStoreInterface;
 use Biig\Melodiia\Exception\ImpossibleToPaginateWithDoctrineRepository;
+use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\ORM\EntityManagerInterface;
 use Pagerfanta\Adapter\DoctrineORMAdapter;
 use Pagerfanta\Pagerfanta;
-use Doctrine\Common\Persistence\ManagerRegistry;
 
 class DoctrineDataStore implements DataStoreInterface
 {
@@ -30,7 +31,7 @@ class DoctrineDataStore implements DataStoreInterface
         return $this->getEntityManager()->getRepository($type)->find($id);
     }
 
-    public function getPaginated(string $type, int $page, $maxPerPage = 30, array $filters = []): PagerFanta
+    public function getPaginated(string $type, int $page, FilterCollection $filters, $maxPerPage = 30): PagerFanta
     {
         $doctrineRepository = $this->getEntityManager()->getRepository($type);
 
@@ -39,10 +40,7 @@ class DoctrineDataStore implements DataStoreInterface
         }
 
         $qb = $doctrineRepository->createQueryBuilder('item');
-
-        foreach ($filters as $filter) {
-            $filter->filter($qb);
-        }
+        $filters->filter($qb);
 
         $pager = new Pagerfanta(new DoctrineORMAdapter($qb));
         $pager->setCurrentPage($page);

--- a/src/Bridge/Symfony/DependencyInjection/MelodiiaExtension.php
+++ b/src/Bridge/Symfony/DependencyInjection/MelodiiaExtension.php
@@ -4,6 +4,7 @@ namespace Biig\Melodiia\Bridge\Symfony\DependencyInjection;
 
 use Biig\Melodiia\Bridge\Symfony\Exception\ConfigException;
 use Biig\Melodiia\Bridge\Symfony\Routing\CrudDocumentationFactory;
+use Biig\Melodiia\Crud\FilterInterface;
 use Biig\Melodiia\Documentation\Controller\OpenApiController;
 use Biig\Melodiia\Documentation\Controller\OpenApiJsonController;
 use Biig\Melodiia\Documentation\OpenApiDocFactory;
@@ -16,6 +17,8 @@ use Symfony\Component\DependencyInjection\Reference;
 
 class MelodiiaExtension extends Extension
 {
+    const TAG_CRUD_FILTER = 'melodiia.crud_filter';
+
     public function load(array $configs, ContainerBuilder $container)
     {
         $loader = new YamlFileLoader(
@@ -33,6 +36,9 @@ class MelodiiaExtension extends Extension
 
         $container->setParameter('melodiia.config', $config);
         $this->disableFormExtensionIfNeeded($container, $config['form_extensions']);
+
+        // Autoconf
+        $container->registerForAutoconfiguration(FilterInterface::class)->addTag(self::TAG_CRUD_FILTER);
     }
 
     private function configureApi(string $name, array $apiConf, ContainerBuilder $container)

--- a/src/Bridge/Symfony/Form/DomainObjectsDataMapper.php
+++ b/src/Bridge/Symfony/Form/DomainObjectsDataMapper.php
@@ -20,18 +20,20 @@ class DomainObjectsDataMapper extends PropertyPathMapper implements DataMapperIn
     /**
      * @param FormInterface[] $form
      * @param string          $dataClass
-     * @return null|object
+     *
      * @throws \ReflectionException
+     *
+     * @return object|null
      */
     public function createObject(iterable $form, string $dataClass = null)
     {
-        if ($dataClass === null && $form instanceof FormInterface) {
+        if (null === $dataClass && $form instanceof FormInterface) {
             $dataClass = $form->getConfig()->getOption('data_class');
         }
 
         $form = iterator_to_array($form);
 
-        if ($dataClass === null || !class_exists($dataClass)) {
+        if (null === $dataClass || !class_exists($dataClass)) {
             return null;
         }
 

--- a/src/Bridge/Symfony/Resources/config/crud.yaml
+++ b/src/Bridge/Symfony/Resources/config/crud.yaml
@@ -4,6 +4,12 @@ services:
         arguments:
             $registry: '@doctrine'
 
+    melodiia.crud.filters.filter_collection_factory:
+        class: Biig\Melodiia\Crud\FilterCollectionFactory
+        arguments:
+            $formFactory: '@form.factory'
+            $filters: !tagged melodiia.crud_filter
+
     melodiia.crud.controller.create:
         class: Biig\Melodiia\Crud\Controller\Create
         arguments:
@@ -27,6 +33,7 @@ services:
         arguments:
             $dataStore: '@melodiia.doctrine.data_provider'
             $checker: '@security.authorization_checker'
+            $collectionFactory: '@melodiia.crud.filters.filter_collection_factory'
         tags: [ controller.service_arguments ]
 
     melodiia.crud.controller.get:

--- a/src/Crud/Controller/Create.php
+++ b/src/Crud/Controller/Create.php
@@ -16,8 +16,8 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
-use Zend\Json\Json;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+use Zend\Json\Json;
 
 /**
  * Crud controller that create data model with the data from the request using a form.

--- a/src/Crud/Controller/GetAll.php
+++ b/src/Crud/Controller/GetAll.php
@@ -2,9 +2,10 @@
 
 namespace Biig\Melodiia\Crud\Controller;
 
+use Biig\Melodiia\Bridge\Symfony\Response\FormErrorResponse;
 use Biig\Melodiia\Crud\CrudableModelInterface;
 use Biig\Melodiia\Crud\CrudControllerInterface;
-use Biig\Melodiia\Crud\FilterInterface;
+use Biig\Melodiia\Crud\FilterCollectionFactoryInterface;
 use Biig\Melodiia\Crud\Persistence\DataStoreInterface;
 use Biig\Melodiia\Exception\MelodiiaLogicException;
 use Biig\Melodiia\Response\OkContent;
@@ -20,14 +21,17 @@ class GetAll implements CrudControllerInterface
     /** @var AuthorizationCheckerInterface */
     private $checker;
 
-    /** @var FilterInterface */
-    private $filters;
+    /** @var FilterCollectionFactoryInterface */
+    private $filterCollectionFactory;
 
-    public function __construct(DataStoreInterface $dataStore, AuthorizationCheckerInterface $checker, array $filters = [])
-    {
+    public function __construct(
+        DataStoreInterface $dataStore,
+        AuthorizationCheckerInterface $checker,
+        FilterCollectionFactoryInterface $collectionFactory
+    ) {
         $this->dataStore = $dataStore;
         $this->checker = $checker;
-        $this->filters = $filters;
+        $this->filterCollectionFactory = $collectionFactory;
     }
 
     public function __invoke(Request $request)
@@ -37,7 +41,10 @@ class GetAll implements CrudControllerInterface
         $securityCheck = $request->attributes->get(self::SECURITY_CHECK, null);
         $groups = $request->attributes->get(self::SERIALIZATION_GROUP, []);
 
-        if (empty($modelClass) || !class_exists($modelClass) || !is_subclass_of($modelClass, CrudableModelInterface::class)) {
+        if (
+            empty($modelClass) || !class_exists($modelClass)
+            || !is_subclass_of($modelClass, CrudableModelInterface::class)
+        ) {
             throw new MelodiiaLogicException('If you use melodiia CRUD classes, you need to specify a model.');
         }
 
@@ -45,10 +52,18 @@ class GetAll implements CrudControllerInterface
             throw new AccessDeniedException(\sprintf('Access denied to data of type "%s".', $modelClass));
         }
 
+        $filters = $this->filterCollectionFactory->createCollection($modelClass);
+        $form = $filters->getForm();
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && !$form->isValid()) {
+            return new FormErrorResponse($form);
+        }
+
         $page = $request->query->getInt('page', 1);
         $maxPerPage = $request->attributes->get(self::MAX_PER_PAGE_ATTRIBUTE, 30);
 
-        $items = $this->dataStore->getPaginated($modelClass, $page, $maxPerPage, $this->filters);
+        $items = $this->dataStore->getPaginated($modelClass, $page, $filters, $maxPerPage);
 
         return new OkContent($items, $groups);
     }

--- a/src/Crud/Controller/Update.php
+++ b/src/Crud/Controller/Update.php
@@ -10,15 +10,14 @@ use Biig\Melodiia\Crud\Event\CustomResponseEvent;
 use Biig\Melodiia\Crud\Persistence\DataStoreInterface;
 use Biig\Melodiia\Exception\MelodiiaLogicException;
 use Biig\Melodiia\Response\ApiResponse;
-use Biig\Melodiia\Response\Ok;
 use Biig\Melodiia\Response\OkContent;
 use Biig\Melodiia\Response\WrongDataInput;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
-use Zend\Json\Json;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+use Zend\Json\Json;
 
 /**
  * Crud controller that update data model with the data from the request using a form.
@@ -67,7 +66,6 @@ final class Update implements CrudControllerInterface
         if (empty($form) || !class_exists($form)) {
             throw new MelodiiaLogicException('If you use melodiia CRUD classes, you need to specify a model.');
         }
-
 
         $form = $this->formFactory->createNamed('', $form, $data);
         $inputData = Json::decode($request->getContent(), Json::TYPE_ARRAY);

--- a/src/Crud/CrudControllerInterface.php
+++ b/src/Crud/CrudControllerInterface.php
@@ -4,9 +4,29 @@ namespace Biig\Melodiia\Crud;
 
 interface CrudControllerInterface
 {
+    /**
+     * This attribute should contain the FQCN to the model.
+     */
     public const MODEL_ATTRIBUTE = 'melodiia_model';
+
+    /**
+     * This attribute should contains the FQCN to the form type to use.
+     */
     public const FORM_ATTRIBUTE = 'melodiia_form';
+
+    /**
+     * This attribute should contains the serialization group to use for serialization concern of the items to return.
+     */
     public const SERIALIZATION_GROUP = 'melodiia_serialization_group';
+
+    /**
+     * If specified, it will process a security check using the value of this attribute.
+     */
     public const SECURITY_CHECK = 'melodiia_security_check';
+
+    /**
+     * Only available for controllers that returns collections of items, it is the number of max item by page.
+     * Controllers MUST define a default value. So you don't have to specify it.
+     */
     public const MAX_PER_PAGE_ATTRIBUTE = 'melodiia_max_per_page';
 }

--- a/src/Crud/FilterCollection.php
+++ b/src/Crud/FilterCollection.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Biig\Melodiia\Crud;
+
+use Biig\Melodiia\Exception\NoFormFilterCreatedException;
+use Doctrine\ORM\QueryBuilder;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\FormInterface;
+
+class FilterCollection
+{
+    /** @var FilterInterface[] */
+    private $filters;
+
+    /** @var FormFactoryInterface */
+    private $formFactory;
+
+    /**
+     * Cached form. This class is stateful.
+     *
+     * @var FormInterface
+     */
+    private $form;
+
+    public function __construct(FormFactoryInterface $formFactory, array $filters)
+    {
+        $this->formFactory = $formFactory;
+        foreach ($filters as $filter) {
+            $this->add($filter);
+        }
+    }
+
+    public function add(FilterInterface $filter): void
+    {
+        $this->filters[] = $filter;
+    }
+
+    public function filter(QueryBuilder $query): void
+    {
+        if (null === $this->form) {
+            throw new NoFormFilterCreatedException('The filter form was not generated. You probably forgot to call `$collection->getForm()->handleRequest($request)`.');
+        }
+
+        foreach ($this->filters as $filter) {
+            $filter->filter($query, $this->getForm());
+        }
+    }
+
+    public function getForm(): FormInterface
+    {
+        if ($this->form) {
+            return $this->form;
+        }
+
+        $builder = $this->formFactory->createNamedBuilder('', FormType::class, null, [
+            'method' => 'GET',
+            'csrf_protection' => false,
+        ]);
+
+        foreach ($this->filters as $filter) {
+            $filter->buildForm($builder);
+        }
+
+        return $this->form = $builder->getForm();
+    }
+}

--- a/src/Crud/FilterCollectionFactory.php
+++ b/src/Crud/FilterCollectionFactory.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Biig\Melodiia\Crud;
+
+use Symfony\Component\Form\FormFactoryInterface;
+
+class FilterCollectionFactory implements FilterCollectionFactoryInterface
+{
+    /** @var FormFactoryInterface */
+    private $formFactory;
+
+    /** @var FilterInterface[] */
+    private $filters;
+
+    public function __construct(FormFactoryInterface $formFactory, iterable $filters = [])
+    {
+        $this->formFactory = $formFactory;
+        $this->filters = $filters;
+    }
+
+    public function createCollection(string $type): FilterCollection
+    {
+        $filters = new FilterCollection($this->formFactory, []);
+
+        foreach ($this->filters as $filter) {
+            if ($filter->supports($type)) {
+                $filters->add($filter);
+            }
+        }
+
+        return $filters;
+    }
+}

--- a/src/Crud/FilterCollectionFactoryInterface.php
+++ b/src/Crud/FilterCollectionFactoryInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Biig\Melodiia\Crud;
+
+interface FilterCollectionFactoryInterface
+{
+    public function createCollection(string $type): FilterCollection;
+}

--- a/src/Crud/FilterInterface.php
+++ b/src/Crud/FilterInterface.php
@@ -2,7 +2,32 @@
 
 namespace Biig\Melodiia\Crud;
 
+use Doctrine\ORM\QueryBuilder;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormInterface;
+
 interface FilterInterface
 {
-    public function filter($query);
+    /**
+     * Takes a query object as parameter. It will be a QueryBuilder in the case of Doctrine usage.
+     *
+     * @param QueryBuilder $queryBuilder The object managed name is `item` inside the given query builder
+     */
+    public function filter(QueryBuilder $queryBuilder, FormInterface $form): void;
+
+    /**
+     * The filter support the class/entity/resource or not.
+     *
+     * @param string $class
+     *
+     * @return bool
+     */
+    public function supports(string $class): bool;
+
+    /**
+     * Adds its data to the form.
+     *
+     * @param FormBuilderInterface $formBuilder
+     */
+    public function buildForm(FormBuilderInterface $formBuilder): void;
 }

--- a/src/Crud/Persistence/DataStoreInterface.php
+++ b/src/Crud/Persistence/DataStoreInterface.php
@@ -2,7 +2,7 @@
 
 namespace Biig\Melodiia\Crud\Persistence;
 
-use Biig\Melodiia\Crud\FilterInterface;
+use Biig\Melodiia\Crud\FilterCollection;
 use Pagerfanta\Pagerfanta;
 
 interface DataStoreInterface
@@ -12,16 +12,18 @@ interface DataStoreInterface
     /**
      * @param string     $type
      * @param string|int $id
-     * @return null|object
+     *
+     * @return object|null
      */
     public function find(string $type, $id): ?object;
 
     /**
-     * @param string             $type
-     * @param int                $page
-     * @param int                $maxPerPage
-     * @param FilterInterface[]  $filters
+     * @param string           $type
+     * @param int              $page
+     * @param FilterCollection $filters
+     * @param int              $maxPerPage
+     *
      * @return Pagerfanta
      */
-    public function getPaginated(string $type, int $page, $maxPerPage = 30, array $filters = []): PagerFanta;
+    public function getPaginated(string $type, int $page, FilterCollection $filters, $maxPerPage = 30): PagerFanta;
 }

--- a/src/Exception/NoFormFilterCreatedException.php
+++ b/src/Exception/NoFormFilterCreatedException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Biig\Melodiia\Exception;
+
+class NoFormFilterCreatedException extends MelodiiaLogicException
+{
+}

--- a/src/Serialization/Json/ExceptionNormalizer.php
+++ b/src/Serialization/Json/ExceptionNormalizer.php
@@ -36,7 +36,7 @@ final class ExceptionNormalizer implements NormalizerInterface
     }
 
     /**
-     * This method is from ApiPlatform core
+     * This method is from ApiPlatform core.
      */
     private function getErrorMessage($object, array $context, bool $debug = false): string
     {
@@ -50,6 +50,7 @@ final class ExceptionNormalizer implements NormalizerInterface
                 $message = Response::$statusTexts[$statusCode];
             }
         }
+
         return $message;
     }
 }

--- a/src/Serialization/Json/OkContentNormalizer.php
+++ b/src/Serialization/Json/OkContentNormalizer.php
@@ -5,11 +5,9 @@ namespace Biig\Melodiia\Serialization\Json;
 use Biig\Melodiia\Response\OkContent;
 use Pagerfanta\Pagerfanta;
 use Symfony\Component\HttpFoundation\RequestStack;
-use Symfony\Component\Routing\Generator\UrlGenerator;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Serializer\SerializerAwareInterface;
 use Symfony\Component\Serializer\SerializerAwareTrait;
-use Symfony\Component\Serializer\SerializerInterface;
 
 /**
  * Class OkContentNormalizer.
@@ -74,7 +72,7 @@ class OkContentNormalizer implements NormalizerInterface, SerializerAwareInterfa
                 'prev' => $previousPage,
                 'next' => $nextPage,
                 'last' => \preg_replace('/([?&])page=(\d+)/', '$1page=' . $content->getNbPages(), $uri),
-                'first' => \preg_replace('/([?&])page=(\d+)/', '$1page=1', $uri)
+                'first' => \preg_replace('/([?&])page=(\d+)/', '$1page=1', $uri),
             ];
         }
 

--- a/tests/Melodiia/Bridge/Doctrine/DoctrineDataStoreTest.php
+++ b/tests/Melodiia/Bridge/Doctrine/DoctrineDataStoreTest.php
@@ -3,14 +3,14 @@
 namespace Biig\Melodiia\Test\Bridge\Doctrine;
 
 use Biig\Melodiia\Bridge\Doctrine\DoctrineDataStore;
-use Biig\Melodiia\Crud\FilterInterface;
+use Biig\Melodiia\Crud\FilterCollection;
 use Biig\Melodiia\Crud\Persistence\DataStoreInterface;
+use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\QueryBuilder;
 use Pagerfanta\Pagerfanta;
 use PHPUnit\Framework\TestCase;
-use Doctrine\Common\Persistence\ManagerRegistry;
 use Prophecy\Argument;
 
 class DoctrineDataStoreTest extends TestCase
@@ -45,11 +45,11 @@ class DoctrineDataStoreTest extends TestCase
         $registry = $this->prophesize(ManagerRegistry::class);
         $registry->getManager()->willReturn($manager->reveal());
 
-        $filter = $this->prophesize(FilterInterface::class);
-        $filter->filter($qb)->shouldBeCalled();
+        $filters = $this->prophesize(FilterCollection::class);
+        $filters->filter($qb)->shouldBeCalled();
 
         $dataStore = new DoctrineDataStore($registry->reveal());
-        $pager = $dataStore->getPaginated('DummyEntity', 1, 30, [$filter->reveal()]);
+        $pager = $dataStore->getPaginated('DummyEntity', 1, $filters->reveal(), 30);
         $this->assertInstanceOf(Pagerfanta::class, $pager);
     }
 }

--- a/tests/Melodiia/Bridge/Symfony/Form/DomainObjectsDataMapperTest.php
+++ b/tests/Melodiia/Bridge/Symfony/Form/DomainObjectsDataMapperTest.php
@@ -2,7 +2,6 @@
 
 namespace Biig\Melodiia\Test\Bridge\Symfony\Form;
 
-
 use Biig\Melodiia\Bridge\Symfony\Form\DomainObjectsDataMapper;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -45,6 +44,7 @@ class FakeValueObject
 
     /**
      * FakeValueObject constructor.
+     *
      * @param $hello
      * @param $foo
      */

--- a/tests/Melodiia/Bridge/Symfony/MelodiiaConfigurationTest.php
+++ b/tests/Melodiia/Bridge/Symfony/MelodiiaConfigurationTest.php
@@ -60,11 +60,11 @@ class MelodiiaConfigurationTest extends TestCase
                     'enable_doc' => false,
                     'doc_factory' => null,
                     'description' => null,
-                ]
+                ],
             ],
             'form_extensions' => [
-                'datetime' => true
-            ]
+                'datetime' => true,
+            ],
         ];
     }
 }

--- a/tests/Melodiia/Crud/Controller/UpdateTest.php
+++ b/tests/Melodiia/Crud/Controller/UpdateTest.php
@@ -9,7 +9,6 @@ use Biig\Melodiia\Crud\Event\CrudEvent;
 use Biig\Melodiia\Crud\Event\CustomResponseEvent;
 use Biig\Melodiia\Crud\Persistence\DataStoreInterface;
 use Biig\Melodiia\Response\ApiResponse;
-use Biig\Melodiia\Response\Ok;
 use Biig\Melodiia\Response\OkContent;
 use Biig\Melodiia\Test\TestFixtures\FakeMelodiiaFormType;
 use Biig\Melodiia\Test\TestFixtures\FakeMelodiiaModel;

--- a/tests/Melodiia/Crud/FilterCollectionFactoryTest.php
+++ b/tests/Melodiia/Crud/FilterCollectionFactoryTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Biig\Melodiia\Test\Crud\Controller;
+
+use Biig\Melodiia\Crud\FilterCollection;
+use Biig\Melodiia\Crud\FilterCollectionFactory;
+use Biig\Melodiia\Crud\FilterCollectionFactoryInterface;
+use Biig\Melodiia\Crud\FilterInterface;
+use Doctrine\ORM\QueryBuilder;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Prophecy\ObjectProphecy;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\FormInterface;
+
+class FilterCollectionFactoryTest extends TestCase
+{
+    /** @var FormFactoryInterface|ObjectProphecy */
+    private $formFactory;
+
+    public function setUp()
+    {
+        $this->formFactory = $this->prophesize(FormFactoryInterface::class);
+    }
+
+    public function testItCreatesCollection()
+    {
+        $subject = new FilterCollectionFactory($this->formFactory->reveal(), [new class() implements FilterInterface {
+            public function filter(QueryBuilder $queryBuilder, FormInterface $form): void
+            { /* do nothing */
+            }
+
+            public function supports(string $class): bool
+            {
+                return \stdClass::class === $class;
+            }
+
+            public function buildForm(FormBuilderInterface $formBuilder): void
+            { /* do nothing */
+            }
+        }]);
+        $this->assertInstanceOf(FilterCollection::class, $subject->createCollection(\stdClass::class));
+    }
+
+    public function testItIsInstanceOfFilterFactory()
+    {
+        $subject = new FilterCollectionFactory($this->formFactory->reveal(), []);
+        $this->assertInstanceOf(FilterCollectionFactoryInterface::class, $subject);
+    }
+}

--- a/tests/Melodiia/Crud/FilterCollectionTest.php
+++ b/tests/Melodiia/Crud/FilterCollectionTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Biig\Melodiia\Test\Crud\Controller;
+
+use Biig\Melodiia\Crud\FilterCollection;
+use Biig\Melodiia\Crud\FilterInterface;
+use Doctrine\ORM\QueryBuilder;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\FormInterface;
+
+class FilterCollectionTest extends TestCase
+{
+    /** @var FormFactoryInterface|ObjectProphecy */
+    private $formFactory;
+
+    public function setUp()
+    {
+        $formBuilder = $this->prophesize(FormBuilderInterface::class);
+        $formBuilder->getForm()->willReturn($this->prophesize(FormInterface::class)->reveal());
+        $this->formFactory = $this->prophesize(FormFactoryInterface::class);
+        $this->formFactory->createNamedBuilder(Argument::cetera())->willReturn($formBuilder->reveal());
+    }
+
+    public function testItFilterQuery()
+    {
+        $filter = $this->prophesize(FilterInterface::class);
+        $filter->filter(Argument::cetera())->shouldBeCalled();
+        $filter->buildForm(Argument::cetera());
+        $collection = new FilterCollection($this->formFactory->reveal(), [$filter->reveal()]);
+        $collection->getForm();
+        $collection->filter($this->prophesize(QueryBuilder::class)->reveal());
+    }
+
+    /**
+     * @expectedException \TypeError
+     */
+    public function testItDoesNotAcceptSomethingElseThanFilter()
+    {
+        $collection = new FilterCollection($this->formFactory->reveal(), [new \stdClass()]);
+    }
+
+    /**
+     * @expectedException \TypeError
+     */
+    public function testItDoesNotAcceptSomethingElseThanFilterInAdd()
+    {
+        $collection = new FilterCollection($this->formFactory->reveal());
+        $collection->add(new \stdClass());
+    }
+
+    public function testItBuildAForm()
+    {
+        /** @var FormBuilderInterface|ObjectProphecy $builder */
+        $builder = $this->prophesize(FormBuilderInterface::class);
+        $builder->add('fake', TextType::class)->shouldBeCalled();
+        $builder->getForm()->willReturn($form = $this->prophesize(FormInterface::class)->reveal())->shouldBeCalled();
+        $this->formFactory->createNamedBuilder(Argument::cetera())->willReturn($builder->reveal());
+
+        $collection = new FilterCollection($this->formFactory->reveal(), [new FakeFilter()]);
+        $collection->getForm();
+    }
+}
+
+class FakeFilter implements FilterInterface
+{
+    public function filter(QueryBuilder $queryBuilder, FormInterface $form): void
+    {
+        // this is fake
+    }
+
+    public function supports(string $class): bool
+    {
+        // this is fake
+    }
+
+    public function buildForm(FormBuilderInterface $formBuilder): void
+    {
+        $formBuilder->add('fake', TextType::class);
+    }
+}

--- a/tests/Melodiia/Serialization/Json/ExceptionNormalizerTest.php
+++ b/tests/Melodiia/Serialization/Json/ExceptionNormalizerTest.php
@@ -13,7 +13,7 @@ class ExceptionNormalizerTest extends TestCase
         $normalizer = new ExceptionNormalizer();
         $this->assertTrue($normalizer->supportsNormalization($this->prophesize(FlattenException::class)->reveal()));
         $this->assertTrue($normalizer->supportsNormalization(new \Exception()));
-        $this->assertFalse($normalizer->supportsNormalization(new \stdClass));
+        $this->assertFalse($normalizer->supportsNormalization(new \stdClass()));
     }
 
     public function testItNormalizeWithoutTraceByDefault()

--- a/tests/Melodiia/Serialization/Json/OkContentNormalizerTest.php
+++ b/tests/Melodiia/Serialization/Json/OkContentNormalizerTest.php
@@ -98,7 +98,7 @@ class OkContentNormalizerTest extends TestCase
     public function testItSerializePager()
     {
         $content = [
-            'foo', 'bar', 'baz', 'hello', 'world', 'more', 'content', 'yaya', 'yoyo', 'random', 'words'
+            'foo', 'bar', 'baz', 'hello', 'world', 'more', 'content', 'yaya', 'yoyo', 'random', 'words',
         ];
         $pager = new Pagerfanta(new ArrayAdapter($content));
         $pager->setMaxPerPage(4);
@@ -107,22 +107,22 @@ class OkContentNormalizerTest extends TestCase
         $this->request->getUri()->willReturn('http://foo.com/bar?page=2');
 
         foreach (['world', 'more', 'content', 'yaya'] as $data) {
-            $this->mainNormalizer->normalize($data, Argument::cetera())->willReturn($data .' normalized')->shouldBeCalled();
+            $this->mainNormalizer->normalize($data, Argument::cetera())->willReturn($data . ' normalized')->shouldBeCalled();
         }
 
         $res = $this->okContentNormalizer->normalize($okContent);
 
         $this->assertEquals([
             'data' => [
-                'world normalized', 'more normalized', 'content normalized', 'yaya normalized'
+                'world normalized', 'more normalized', 'content normalized', 'yaya normalized',
             ],
             'meta' => ['totalPages' => 3],
             'links' => [
                 'prev' => 'http://foo.com/bar?page=1',
                 'next' => 'http://foo.com/bar?page=3',
                 'last' => 'http://foo.com/bar?page=3',
-                'first' => 'http://foo.com/bar?page=1'
-            ]
+                'first' => 'http://foo.com/bar?page=1',
+            ],
         ], $res);
     }
 }

--- a/tests/Melodiia/TestFixtures/FakeMelodiiaFormType.php
+++ b/tests/Melodiia/TestFixtures/FakeMelodiiaFormType.php
@@ -6,5 +6,4 @@ use Biig\Melodiia\Bridge\Symfony\Form\AbstractType;
 
 class FakeMelodiiaFormType extends AbstractType
 {
-
 }


### PR DESCRIPTION
Filters were just little class without possibilities. This commit
adds a complete system for filters based on form.

This means that it can:
- Validate filters
- Answer consistent API responses

Filters are now super easy to create, this commit adds a documentation
about.

Please consider this commit highly breaks the compatibility. Some of
this breaks could have been avoided but it is done this way because
Melodiia is not stable ATM.

Note about filters that only support Doctrine: for now there's nothing
else than Doctrine supported by Melodiia. It could be nice to add a way
that allow us to bring more inside Melodiia. But it's not a nice DX
considering it needs us to drop some type hinting and we have no
replacement for now.