### PR TITLE
Add bc layer for Symfony < 4.2

### DIFF
--- a/src/Bridge/Symfony/DependencyInjection/Configuration.php
+++ b/src/Bridge/Symfony/DependencyInjection/Configuration.php
@@ -9,8 +9,14 @@ class Configuration implements ConfigurationInterface
 {
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('melodiia');
+        $treeBuilder = new TreeBuilder('melodiia');
+        
+        if (method_exists($treeBuilder, 'getRootNode')) {
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            // BC for symfony/config < 4.2
+            $rootNode = $treeBuilder->root('melodiia');
+        }
 
         $rootNode
             ->children()


### PR DESCRIPTION
Symfony 4.2 added a new way to define root node of bundle configuration.
This commit adds it to Melodiia and keeps compatibility with old versions of Symfony by using a cool Backward Compatibility layer.