### PR TITLE
Fix missing default value for an attribute

### DIFF
--- a/src/Crud/FilterCollection.php
+++ b/src/Crud/FilterCollection.php
@@ -26,6 +26,7 @@ class FilterCollection
     public function __construct(FormFactoryInterface $formFactory, array $filters)
     {
         $this->formFactory = $formFactory;
+        $this->filters = [];
         foreach ($filters as $filter) {
             $this->add($filter);
         }

--- a/tests/Melodiia/Crud/FilterCollectionTest.php
+++ b/tests/Melodiia/Crud/FilterCollectionTest.php
@@ -64,6 +64,18 @@ class FilterCollectionTest extends TestCase
         $collection = new FilterCollection($this->formFactory->reveal(), [new FakeFilter()]);
         $collection->getForm();
     }
+
+    public function testItBuildsAFormEvenWithNoFilters()
+    {
+        /** @var FormBuilderInterface|ObjectProphecy $builder */
+        $builder = $this->prophesize(FormBuilderInterface::class);
+        $builder->add('fake', TextType::class)->shouldNotBeCalled();
+        $builder->getForm()->willReturn($form = $this->prophesize(FormInterface::class)->reveal())->shouldBeCalled();
+        $this->formFactory->createNamedBuilder(Argument::cetera())->willReturn($builder->reveal());
+
+        $collection = new FilterCollection($this->formFactory->reveal(), []);
+        $collection->getForm();
+    }
 }
 
 class FakeFilter implements FilterInterface


### PR DESCRIPTION
The default value of filters array in FilterCollection was not set. This lead to a failure in case there's no filter defined.