### PR TITLE
Doc initialization: use schem from request

### DIFF
--- a/src/Documentation/OpenApiDocFactory.php
+++ b/src/Documentation/OpenApiDocFactory.php
@@ -37,7 +37,7 @@ final class OpenApiDocFactory implements DocumentationFactoryInterface
             ]),
             'paths' => [],
             'servers' => [
-                ['url' => 'http://' . $this->getApiPath()],
+                ['url' => $this->getApiUrl()],
             ],
         ];
 
@@ -49,13 +49,13 @@ final class OpenApiDocFactory implements DocumentationFactoryInterface
         return $analysis;
     }
 
-    private function getApiPath()
+    private function getApiUrl()
     {
         $path = $this->config['base_path'];
         if (!StringTools::startsWith($path, '/')) {
             $path = '/' . $path;
         }
 
-        return $this->requestStack->getMasterRequest()->getHttpHost() . $path;
+        return $this->requestStack->getMasterRequest()->getSchemeAndHttpHost() . $path;
     }
 }

--- a/tests/Melodiia/Bridge/Symfony/Routing/CrudDocumentationFactoryTest.php
+++ b/tests/Melodiia/Bridge/Symfony/Routing/CrudDocumentationFactoryTest.php
@@ -59,7 +59,7 @@ class CrudDocumentationFactoryTest extends TestCase
     {
         // Mocks
         $request = $this->prophesize(Request::class);
-        $request->getHttpHost()->willReturn('http://localhost:9999');
+        $request->getSchemeAndHttpHost()->willReturn('http://localhost:9999');
         $requestStack = $this->prophesize(RequestStack::class);
         $requestStack->getMasterRequest()->willReturn($request->reveal());
 

--- a/tests/Melodiia/Documentation/OpenApiDocFactoryTest.php
+++ b/tests/Melodiia/Documentation/OpenApiDocFactoryTest.php
@@ -35,7 +35,7 @@ class OpenApiDocFactoryTest extends TestCase
             'description' => null,
         ]);
         $request = $this->prophesize(Request::class);
-        $request->getHttpHost()->willReturn('http://localhost');
+        $request->getSchemeAndHttpHost()->willReturn('http://localhost');
         $this->requestStack->getMasterRequest()->willReturn($request);
         $this->assertInstanceOf(Analysis::class, $factory->createOpenApiAnalysis());
     }


### PR DESCRIPTION
We enforced HTTP while most APIs now use https. The best option is to use (again) the available request in the related class.