### PR TITLE
Add new option custom data mapper on ApiType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- #22 Add possibility to define a custom data normalizer for ApiType 
+
 ## [0.3.2] - 2019-07-05
 ### Changed
 - #19 Documentation is now using scheme of the application

--- a/src/Bridge/Symfony/Form/DomainObjectDataMapperInterface.php
+++ b/src/Bridge/Symfony/Form/DomainObjectDataMapperInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Biig\Melodiia\Bridge\Symfony\Form;
+
+use Symfony\Component\Form\DataMapperInterface;
+
+interface DomainObjectDataMapperInterface extends DataMapperInterface
+{
+    /**
+     * @param iterable    $form
+     * @param string|null $dataClass
+     *
+     * @return mixed
+     */
+    public function createObject(iterable $form, string $dataClass = null);
+}

--- a/src/Bridge/Symfony/Form/DomainObjectsDataMapper.php
+++ b/src/Bridge/Symfony/Form/DomainObjectsDataMapper.php
@@ -9,7 +9,7 @@ use Symfony\Component\Form\FormInterface;
 /**
  * Add support for objects that require constructor instantiation.
  */
-class DomainObjectsDataMapper extends PropertyPathMapper implements DataMapperInterface
+class DomainObjectsDataMapper extends PropertyPathMapper implements DomainObjectDataMapperInterface
 {
     public function mapFormsToData($forms, &$data)
     {
@@ -18,12 +18,7 @@ class DomainObjectsDataMapper extends PropertyPathMapper implements DataMapperIn
     }
 
     /**
-     * @param FormInterface[] $form
-     * @param string          $dataClass
-     *
-     * @throws \ReflectionException
-     *
-     * @return object|null
+     * {@inheritDoc}
      */
     public function createObject(iterable $form, string $dataClass = null)
     {

--- a/src/Bridge/Symfony/Form/Type/ApiType.php
+++ b/src/Bridge/Symfony/Form/Type/ApiType.php
@@ -21,6 +21,12 @@ class ApiType extends AbstractType
 
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
+        $dataMapper = $this->dataMapper;
+
+        if ($options['customDataMapper'] !== null) {
+            $dataMapper = $options['customDataMapper'];
+        }
+
         if ($options['value_object']) {
             $builder->setDataMapper($this->dataMapper);
         }
@@ -31,6 +37,7 @@ class ApiType extends AbstractType
         $resolver->setDefaults([
             'csrf_protection' => false,
             'value_object' => false,
+            'customDataMapper' => null,
 
             /*
              * Creates data object just like standard form would do
@@ -41,8 +48,15 @@ class ApiType extends AbstractType
              * @throws \ReflectionException
              */
             'empty_data' => function (FormInterface $form) {
-                return $this->dataMapper->createObject($form);
+                $dataMapper = $this->dataMapper;
+                if ($form->getConfig()->getOption('customDataMapper') !== null) {
+                    $dataMapper = $form->getConfig()->getOption('customDataMapper');
+                }
+
+                return $dataMapper->createObject($form);
             },
         ]);
+
+        $resolver->setAllowedTypes('customDataMapper', ['null', DomainObjectsDataMapper::class]);
     }
 }


### PR DESCRIPTION
The reason for this addition is that the ApiType is a great shortcut. But defining the data mapper was a pain considering it's a custom one also used for instantiation of items.

This new options makes customization smooth.

It also adds a new interface because we need to type hint the `customDataMapper` and the method `createObject` is definitely important.