### PR TITLE
Filters and datastore more compatible #25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0]
+- #25 Improve compatibility of CRUD stuff, but breaks the compatibility
+
 ## [0.3.3] - 2019-08-01
 - #22 Add possibility to define a custom data normalizer for ApiType 
 

--- a/src/Bridge/Doctrine/DoctrineDataStore.php
+++ b/src/Bridge/Doctrine/DoctrineDataStore.php
@@ -2,7 +2,7 @@
 
 namespace Biig\Melodiia\Bridge\Doctrine;
 
-use Biig\Melodiia\Crud\FilterCollection;
+use Biig\Melodiia\Crud\FilterCollectionInterface;
 use Biig\Melodiia\Crud\Persistence\DataStoreInterface;
 use Biig\Melodiia\Exception\ImpossibleToPaginateWithDoctrineRepository;
 use Doctrine\Common\Persistence\ManagerRegistry;
@@ -13,7 +13,7 @@ use Pagerfanta\Pagerfanta;
 class DoctrineDataStore implements DataStoreInterface
 {
     /** @var ManagerRegistry */
-    private $doctrineRegistry;
+    protected $doctrineRegistry;
 
     public function __construct(ManagerRegistry $registry)
     {
@@ -31,7 +31,7 @@ class DoctrineDataStore implements DataStoreInterface
         return $this->getEntityManager()->getRepository($type)->find($id);
     }
 
-    public function getPaginated(string $type, int $page, FilterCollection $filters, $maxPerPage = 30): PagerFanta
+    public function getPaginated(string $type, int $page, FilterCollectionInterface $filters, $maxPerPage = 30): PagerFanta
     {
         $doctrineRepository = $this->getEntityManager()->getRepository($type);
 

--- a/src/Crud/FilterCollection.php
+++ b/src/Crud/FilterCollection.php
@@ -3,15 +3,14 @@
 namespace Biig\Melodiia\Crud;
 
 use Biig\Melodiia\Exception\NoFormFilterCreatedException;
-use Doctrine\ORM\QueryBuilder;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 
-class FilterCollection
+class FilterCollection implements FilterCollectionInterface
 {
     /** @var FilterInterface[] */
-    private $filters;
+    protected $filters;
 
     /** @var FormFactoryInterface */
     private $formFactory;
@@ -37,7 +36,7 @@ class FilterCollection
         $this->filters[] = $filter;
     }
 
-    public function filter(QueryBuilder $query): void
+    public function filter($query): void
     {
         if (null === $this->form) {
             throw new NoFormFilterCreatedException('The filter form was not generated. You probably forgot to call `$collection->getForm()->handleRequest($request)`.');

--- a/src/Crud/FilterCollectionFactory.php
+++ b/src/Crud/FilterCollectionFactory.php
@@ -7,10 +7,10 @@ use Symfony\Component\Form\FormFactoryInterface;
 class FilterCollectionFactory implements FilterCollectionFactoryInterface
 {
     /** @var FormFactoryInterface */
-    private $formFactory;
+    protected $formFactory;
 
     /** @var FilterInterface[] */
-    private $filters;
+    protected $filters;
 
     public function __construct(FormFactoryInterface $formFactory, iterable $filters = [])
     {
@@ -18,9 +18,9 @@ class FilterCollectionFactory implements FilterCollectionFactoryInterface
         $this->filters = $filters;
     }
 
-    public function createCollection(string $type): FilterCollection
+    public function createCollection(string $type): FilterCollectionInterface
     {
-        $filters = new FilterCollection($this->formFactory, []);
+        $filters = $this->getInstance();
 
         foreach ($this->filters as $filter) {
             if ($filter->supports($type)) {
@@ -29,5 +29,10 @@ class FilterCollectionFactory implements FilterCollectionFactoryInterface
         }
 
         return $filters;
+    }
+
+    protected function getInstance(): FilterCollectionInterface
+    {
+        return new FilterCollection($this->formFactory, []);
     }
 }

--- a/src/Crud/FilterCollectionFactoryInterface.php
+++ b/src/Crud/FilterCollectionFactoryInterface.php
@@ -4,5 +4,5 @@ namespace Biig\Melodiia\Crud;
 
 interface FilterCollectionFactoryInterface
 {
-    public function createCollection(string $type): FilterCollection;
+    public function createCollection(string $type): FilterCollectionInterface;
 }

--- a/src/Crud/FilterCollectionInterface.php
+++ b/src/Crud/FilterCollectionInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Biig\Melodiia\Crud;
+
+use Symfony\Component\Form\FormInterface;
+
+/**
+ * This interface is used in context of Melodiia CRUD.
+ * Which work with Symfony Form component.
+ */
+interface FilterCollectionInterface
+{
+    public function add(FilterInterface $filter): void;
+
+    /**
+     * Executes filters against a query.
+     *
+     * @param mixed $query
+     */
+    public function filter($query): void;
+
+    /**
+     * Creates the filter form.
+     *
+     * @return FormInterface
+     */
+    public function getForm(): FormInterface;
+}

--- a/src/Crud/FilterInterface.php
+++ b/src/Crud/FilterInterface.php
@@ -11,9 +11,9 @@ interface FilterInterface
     /**
      * Takes a query object as parameter. It will be a QueryBuilder in the case of Doctrine usage.
      *
-     * @param QueryBuilder $queryBuilder The object managed name is `item` inside the given query builder
+     * @param mixed $queryBuilder The object managed name is `item` inside the given query builder
      */
-    public function filter(QueryBuilder $queryBuilder, FormInterface $form): void;
+    public function filter($queryBuilder, FormInterface $form): void;
 
     /**
      * The filter support the class/entity/resource or not.

--- a/src/Crud/Persistence/DataStoreInterface.php
+++ b/src/Crud/Persistence/DataStoreInterface.php
@@ -2,7 +2,7 @@
 
 namespace Biig\Melodiia\Crud\Persistence;
 
-use Biig\Melodiia\Crud\FilterCollection;
+use Biig\Melodiia\Crud\FilterCollectionInterface;
 use Pagerfanta\Pagerfanta;
 
 interface DataStoreInterface
@@ -18,12 +18,12 @@ interface DataStoreInterface
     public function find(string $type, $id): ?object;
 
     /**
-     * @param string           $type
-     * @param int              $page
-     * @param FilterCollection $filters
-     * @param int              $maxPerPage
+     * @param string                    $type
+     * @param int                       $page
+     * @param FilterCollectionInterface $filters
+     * @param int                       $maxPerPage
      *
      * @return Pagerfanta
      */
-    public function getPaginated(string $type, int $page, FilterCollection $filters, $maxPerPage = 30): PagerFanta;
+    public function getPaginated(string $type, int $page, FilterCollectionInterface $filters, $maxPerPage = 30): PagerFanta;
 }

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Biig\Melodiia\Exception;
+
+class InvalidArgumentException extends \InvalidArgumentException implements MelodiiaException
+{
+}

--- a/tests/Melodiia/Crud/FilterCollectionFactoryTest.php
+++ b/tests/Melodiia/Crud/FilterCollectionFactoryTest.php
@@ -6,7 +6,6 @@ use Biig\Melodiia\Crud\FilterCollection;
 use Biig\Melodiia\Crud\FilterCollectionFactory;
 use Biig\Melodiia\Crud\FilterCollectionFactoryInterface;
 use Biig\Melodiia\Crud\FilterInterface;
-use Doctrine\ORM\QueryBuilder;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Prophecy\ObjectProphecy;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -26,7 +25,7 @@ class FilterCollectionFactoryTest extends TestCase
     public function testItCreatesCollection()
     {
         $subject = new FilterCollectionFactory($this->formFactory->reveal(), [new class() implements FilterInterface {
-            public function filter(QueryBuilder $queryBuilder, FormInterface $form): void
+            public function filter($queryBuilder, FormInterface $form): void
             { /* do nothing */
             }
 

--- a/tests/Melodiia/Crud/FilterCollectionTest.php
+++ b/tests/Melodiia/Crud/FilterCollectionTest.php
@@ -80,7 +80,7 @@ class FilterCollectionTest extends TestCase
 
 class FakeFilter implements FilterInterface
 {
-    public function filter(QueryBuilder $queryBuilder, FormInterface $form): void
+    public function filter($queryBuilder, FormInterface $form): void
     {
         // this is fake
     }


### PR DESCRIPTION
Doctrine stuff was really hardcoded in the interface of filter and datastore. This commit removes the dependency in the interface and allow the user to makes custom dataprovider using something else than doctrine query builder (such as native query builder). Or maybe completely something else than doctrine.