### PR TITLE
Fix #38 by adding DateTimeType

### DIFF
--- a/src/Bridge/Symfony/Form/Type/DateTimeType.php
+++ b/src/Bridge/Symfony/Form/Type/DateTimeType.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Biig\Melodiia\Bridge\Symfony\Form\Type;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Form\Extension\Core\Type\DateTimeType as OriginalDateTimeType;
+
+class DateTimeType extends AbstractType
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver
+            ->setDefaults([
+                'widget' => 'single_text',
+                'format' => OriginalDateTimeType::HTML5_FORMAT,
+                'input' => 'datetime_immutable',
+            ])
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getParent()
+    {
+        return OriginalDateTimeType::class;
+    }
+}

--- a/tests/Melodiia/Bridge/Symfony/Form/DateTimeTypeTest.php
+++ b/tests/Melodiia/Bridge/Symfony/Form/DateTimeTypeTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Biig\Melodiia\Test\Bridge\Symfony\Form;
+
+use Biig\Melodiia\Bridge\Symfony\Form\Type\DateTimeType;
+use Symfony\Component\Form\Test\TypeTestCase;
+
+class DateTimeTypeTest extends TypeTestCase
+{
+    public function testItChangesDefaultOptions()
+    {
+        $form = $this->factory->create(DateTimeType::class, null, [
+        ]);
+        $form->submit('2010-09-30T00:00:00');
+        $dateTime = new \DateTimeImmutable('2010-09-30');
+
+        $this->assertEquals($dateTime, $form->getData());
+    }
+
+    protected function getTestedType()
+    {
+        return DateTimeType::class;
+    }
+}


### PR DESCRIPTION
This type also generates immutable datetime by default, this is done to promote defensive programming and good practices. (it's overridable as any other form type option).
The default format choose is HTML5, which is also easy to generate in javascript.