### PR TITLE
Refacto check of model class by creating a controller trait

### DIFF
--- a/src/Crud/Controller/Create.php
+++ b/src/Crud/Controller/Create.php
@@ -3,7 +3,6 @@
 namespace Biig\Melodiia\Crud\Controller;
 
 use Biig\Melodiia\Bridge\Symfony\Response\FormErrorResponse;
-use Biig\Melodiia\Crud\CrudableModelInterface;
 use Biig\Melodiia\Crud\CrudControllerInterface;
 use Biig\Melodiia\Crud\Event\CrudEvent;
 use Biig\Melodiia\Crud\Event\CustomResponseEvent;
@@ -24,6 +23,8 @@ use Zend\Json\Json;
  */
 final class Create implements CrudControllerInterface
 {
+    use CrudControllerTrait;
+
     public const EVENT_PRE_CREATE = 'melodiia.crud.pre_create';
     public const EVENT_POST_CREATE = 'melodiia.crud.post_create';
 
@@ -54,9 +55,7 @@ final class Create implements CrudControllerInterface
         $form = $request->attributes->get(self::FORM_ATTRIBUTE);
         $securityCheck = $request->attributes->get(self::SECURITY_CHECK, null);
 
-        if (empty($modelClass) || !class_exists($modelClass) || !is_subclass_of($modelClass, CrudableModelInterface::class)) {
-            throw new MelodiiaLogicException('If you use melodiia CRUD classes, you need to specify a model.');
-        }
+        $this->assertModelClassInvalid($modelClass);
 
         if ($securityCheck && !$this->checker->isGranted($securityCheck)) {
             throw new AccessDeniedException(\sprintf('Access denied to data of type "%s".', $modelClass));

--- a/src/Crud/Controller/CrudControllerTrait.php
+++ b/src/Crud/Controller/CrudControllerTrait.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+
+namespace Biig\Melodiia\Crud\Controller;
+
+use Biig\Melodiia\Crud\CrudableModelInterface;
+use Biig\Melodiia\Exception\MelodiiaLogicException;
+
+trait CrudControllerTrait
+{
+    /**
+     * @param string $modelClass FQCN of the model class
+     * @throws MelodiiaLogicException if the model class don't match Melodiia requirements
+     */
+    public function assertModelClassInvalid(string $modelClass): void
+    {
+        if (empty($modelClass) || !class_exists($modelClass) || !is_subclass_of($modelClass, CrudableModelInterface::class)) {
+            throw new MelodiiaLogicException('If you use melodiia CRUD classes, you need to specify a model.');
+        }
+    }
+}

--- a/src/Crud/Controller/Delete.php
+++ b/src/Crud/Controller/Delete.php
@@ -2,12 +2,10 @@
 
 namespace Biig\Melodiia\Crud\Controller;
 
-use Biig\Melodiia\Crud\CrudableModelInterface;
 use Biig\Melodiia\Crud\CrudControllerInterface;
 use Biig\Melodiia\Crud\Event\CrudEvent;
 use Biig\Melodiia\Crud\Event\CustomResponseEvent;
 use Biig\Melodiia\Crud\Persistence\DataStoreInterface;
-use Biig\Melodiia\Exception\MelodiiaLogicException;
 use Biig\Melodiia\Response\Ok;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -17,6 +15,8 @@ use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
 final class Delete implements CrudControllerInterface
 {
+    use CrudControllerTrait;
+
     public const EVENT_PRE_DELETE = 'melodiia.crud.pre_delete';
     public const EVENT_POST_DELETE = 'melodiia.crud.post_delete';
 
@@ -41,9 +41,7 @@ final class Delete implements CrudControllerInterface
         $modelClass = $request->attributes->get(self::MODEL_ATTRIBUTE);
         $securityCheck = $request->attributes->get(self::SECURITY_CHECK, null);
 
-        if (empty($modelClass) || !class_exists($modelClass) || !is_subclass_of($modelClass, CrudableModelInterface::class)) {
-            throw new MelodiiaLogicException('If you use melodiia CRUD classes, you need to specify a model.');
-        }
+        $this->assertModelClassInvalid($modelClass);
 
         $data = $this->dataStore->find($modelClass, $id);
 

--- a/src/Crud/Controller/Get.php
+++ b/src/Crud/Controller/Get.php
@@ -13,6 +13,8 @@ use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
 final class Get implements CrudControllerInterface
 {
+    use CrudControllerTrait;
+
     /** @var DataStoreInterface */
     private $dataStore;
 
@@ -30,6 +32,8 @@ final class Get implements CrudControllerInterface
         $modelClass = $request->attributes->get(self::MODEL_ATTRIBUTE);
         $groups = $request->attributes->get(self::SERIALIZATION_GROUP, []);
         $securityCheck = $request->attributes->get(self::SECURITY_CHECK, null);
+
+        $this->assertModelClassInvalid($modelClass);
 
         $data = $this->dataStore->find($modelClass, $id);
 

--- a/src/Crud/Controller/GetAll.php
+++ b/src/Crud/Controller/GetAll.php
@@ -3,12 +3,10 @@
 namespace Biig\Melodiia\Crud\Controller;
 
 use Biig\Melodiia\Bridge\Symfony\Response\FormErrorResponse;
-use Biig\Melodiia\Crud\CrudableModelInterface;
 use Biig\Melodiia\Crud\CrudControllerInterface;
 use Biig\Melodiia\Crud\FilterCollectionFactoryInterface;
 use Biig\Melodiia\Crud\Pagination\PaginationRequestFactoryInterface;
 use Biig\Melodiia\Crud\Persistence\DataStoreInterface;
-use Biig\Melodiia\Exception\MelodiiaLogicException;
 use Biig\Melodiia\Response\OkContent;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
@@ -16,6 +14,8 @@ use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
 class GetAll implements CrudControllerInterface
 {
+    use CrudControllerTrait;
+
     /** @var DataStoreInterface */
     private $dataStore;
 
@@ -47,12 +47,7 @@ class GetAll implements CrudControllerInterface
         $securityCheck = $request->attributes->get(self::SECURITY_CHECK, null);
         $groups = $request->attributes->get(self::SERIALIZATION_GROUP, []);
 
-        if (
-            empty($modelClass) || !class_exists($modelClass)
-            || !is_subclass_of($modelClass, CrudableModelInterface::class)
-        ) {
-            throw new MelodiiaLogicException('If you use melodiia CRUD classes, you need to specify a model.');
-        }
+        $this->assertModelClassInvalid($modelClass);
 
         if ($securityCheck && !$this->checker->isGranted($securityCheck)) {
             throw new AccessDeniedException(\sprintf('Access denied to data of type "%s".', $modelClass));

--- a/src/Crud/Controller/Update.php
+++ b/src/Crud/Controller/Update.php
@@ -3,7 +3,6 @@
 namespace Biig\Melodiia\Crud\Controller;
 
 use Biig\Melodiia\Bridge\Symfony\Response\FormErrorResponse;
-use Biig\Melodiia\Crud\CrudableModelInterface;
 use Biig\Melodiia\Crud\CrudControllerInterface;
 use Biig\Melodiia\Crud\Event\CrudEvent;
 use Biig\Melodiia\Crud\Event\CustomResponseEvent;
@@ -24,6 +23,8 @@ use Zend\Json\Json;
  */
 final class Update implements CrudControllerInterface
 {
+    use CrudControllerTrait;
+
     public const EVENT_PRE_UPDATE = 'melodiia.crud.pre_update';
     public const EVENT_POST_UPDATE = 'melodiia.crud.post_update';
 
@@ -53,9 +54,7 @@ final class Update implements CrudControllerInterface
         $form = $request->attributes->get(self::FORM_ATTRIBUTE);
         $securityCheck = $request->attributes->get(self::SECURITY_CHECK, null);
 
-        if (empty($modelClass) || !class_exists($modelClass) || !is_subclass_of($modelClass, CrudableModelInterface::class)) {
-            throw new MelodiiaLogicException('If you use melodiia CRUD classes, you need to specify a model.');
-        }
+        $this->assertModelClassInvalid($modelClass);
 
         $data = $this->dataStore->find($modelClass, $id);
 

--- a/tests/Melodiia/Crud/Controller/GetTest.php
+++ b/tests/Melodiia/Crud/Controller/GetTest.php
@@ -7,6 +7,7 @@ use Biig\Melodiia\Crud\CrudControllerInterface;
 use Biig\Melodiia\Crud\Persistence\DataStoreInterface;
 use Biig\Melodiia\Response\NotFound;
 use Biig\Melodiia\Response\OkContent;
+use Biig\Melodiia\Test\TestFixtures\FakeMelodiiaModel;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
@@ -39,10 +40,10 @@ class GetTest extends TestCase
 
     public function testItReturnResourceFromDataStoreInsideOkContent()
     {
-        $this->dataStore->find('foo', 'id')->willReturn(new \stdClass())->shouldBeCalled();
+        $this->dataStore->find(FakeMelodiiaModel::class, 'id')->willReturn(new \stdClass())->shouldBeCalled();
         $request = $this->prophesize(Request::class);
         $attributes = $this->prophesize(ParameterBag::class);
-        $attributes->get(CrudControllerInterface::MODEL_ATTRIBUTE)->willReturn('foo');
+        $attributes->get(CrudControllerInterface::MODEL_ATTRIBUTE)->willReturn(FakeMelodiiaModel::class);
         $attributes->get(CrudControllerInterface::SERIALIZATION_GROUP, [])->willReturn([]);
         $attributes->get(CrudControllerInterface::SECURITY_CHECK, null)->willReturn(null);
         $request->attributes = $attributes->reveal();
@@ -55,10 +56,10 @@ class GetTest extends TestCase
 
     public function testItReturnNotFoundResponseInCaseOfNoResultFromDataStore()
     {
-        $this->dataStore->find('foo', 'id')->willReturn(null)->shouldBeCalled();
+        $this->dataStore->find(FakeMelodiiaModel::class, 'id')->willReturn(null)->shouldBeCalled();
         $request = $this->prophesize(Request::class);
         $attributes = $this->prophesize(ParameterBag::class);
-        $attributes->get(CrudControllerInterface::MODEL_ATTRIBUTE)->willReturn('foo');
+        $attributes->get(CrudControllerInterface::MODEL_ATTRIBUTE)->willReturn(FakeMelodiiaModel::class);
         $attributes->get(CrudControllerInterface::SERIALIZATION_GROUP, [])->willReturn([]);
         $attributes->get(CrudControllerInterface::SECURITY_CHECK, null)->willReturn(null);
         $request->attributes = $attributes->reveal();
@@ -73,10 +74,10 @@ class GetTest extends TestCase
      */
     public function testItCheckAccessToResourceIfSpecifiedInConfiguration()
     {
-        $this->dataStore->find('foo', 'id')->willReturn(new \stdClass())->shouldBeCalled();
+        $this->dataStore->find(FakeMelodiiaModel::class, 'id')->willReturn(new \stdClass())->shouldBeCalled();
         $request = $this->prophesize(Request::class);
         $attributes = $this->prophesize(ParameterBag::class);
-        $attributes->get(CrudControllerInterface::MODEL_ATTRIBUTE)->willReturn('foo');
+        $attributes->get(CrudControllerInterface::MODEL_ATTRIBUTE)->willReturn(FakeMelodiiaModel::class);
         $attributes->get(CrudControllerInterface::SERIALIZATION_GROUP, [])->willReturn([]);
         $attributes->get(CrudControllerInterface::SECURITY_CHECK, null)->willReturn('view');
         $request->attributes = $attributes->reveal();
@@ -88,10 +89,10 @@ class GetTest extends TestCase
 
     public function testItCheckAccessAndSuccessIfAuthorized()
     {
-        $this->dataStore->find('foo', 'id')->willReturn(new \stdClass())->shouldBeCalled();
+        $this->dataStore->find(FakeMelodiiaModel::class, 'id')->willReturn(new \stdClass())->shouldBeCalled();
         $request = $this->prophesize(Request::class);
         $attributes = $this->prophesize(ParameterBag::class);
-        $attributes->get(CrudControllerInterface::MODEL_ATTRIBUTE)->willReturn('foo');
+        $attributes->get(CrudControllerInterface::MODEL_ATTRIBUTE)->willReturn(FakeMelodiiaModel::class);
         $attributes->get(CrudControllerInterface::SERIALIZATION_GROUP, [])->willReturn([]);
         $attributes->get(CrudControllerInterface::SECURITY_CHECK, null)->willReturn('view');
         $request->attributes = $attributes->reveal();


### PR DESCRIPTION
This check is done in all Crud Controllers. Let's create a trait to avoid duplicate code :)

```php
empty($modelClass) || !class_exists($modelClass) || !is_subclass_of($modelClass, CrudableModelInterface::class);
```