### PR TITLE
Fix extra fields into query Params

### DIFF
--- a/src/Crud/FilterCollection.php
+++ b/src/Crud/FilterCollection.php
@@ -56,6 +56,7 @@ class FilterCollection implements FilterCollectionInterface
         $builder = $this->formFactory->createNamedBuilder('', FormType::class, null, [
             'method' => 'GET',
             'csrf_protection' => false,
+            'allow_extra_fields' => true,
         ]);
 
         foreach ($this->filters as $filter) {


### PR DESCRIPTION
Current behavior: 
Melodiia cannot combine search and paging parameters.

Expected behavior:
Melodiia can combine search (and others) and paging parameters in the same request.