### PR TITLE
Support: add issue template for github

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,21 @@
+**I'm submitting a ...**  (check one with "x")
+```
+[ ] bug report => search github for a similar issue or PR before submitting
+[ ] feature request
+[ ] support request => Please do not submit support request here, post on Stackoverflow or Gitter
+```
+
+**Current behavior**
+<!-- Describe how the bug manifests. -->
+
+**Expected behavior**
+<!-- Describe what the behavior would be without the bug. -->
+
+**What is the motivation / use case for changing the behavior?**
+<!-- Describe the motivation or the concrete use case -->
+
+* **Melodiia version:** 0.4.x
+<!-- Check whether this is still an issue in the most recent table version -->
+
+* **Symfony version:** 4.x.x
+<!-- Check whether this is still an issue in the most recent Angular version -->


### PR DESCRIPTION
Add a default issue template.

I suggest to add keywords on repo description 🤘 