### PR TITLE
Make form error response more consistent

### DIFF
--- a/src/Bridge/Symfony/Response/FormErrorResponse.php
+++ b/src/Bridge/Symfony/Response/FormErrorResponse.php
@@ -62,6 +62,11 @@ class FormErrorResponse extends AbstractUserDataErrorResponse
         do {
             $part = (string) $form->getPropertyPath();
 
+            // Transform "[foo]" property path to "foo"
+            if (StringTools::startsWith($part, '[') && !is_numeric($objectPropertyPath = StringTools::removeEnd(StringTools::removeStart($part, '['), ']'))) {
+                $part = $objectPropertyPath;
+            }
+
             // Basically this condition means the data is object so we need a dot
             if (!empty($propertyPath) && !StringTools::startsWith($propertyPath, '[')) {
                 $propertyPath = '.' . $propertyPath;

--- a/tests/Melodiia/Bridge/Symfony/Response/FormErrorResponseTest.php
+++ b/tests/Melodiia/Bridge/Symfony/Response/FormErrorResponseTest.php
@@ -66,10 +66,10 @@ class FormErrorResponseTest extends TestCase
         $formErrorResponse = new FormErrorResponse($form);
         $this->assertInternalType('array', $errors = $formErrorResponse->getErrors());
         $this->assertCount(1, $errors);
-        $this->assertInstanceOf(UserDataError::class, $errors['[foo]']);
-        $this->assertEquals('[foo]', $errors['[foo]']->getPropertyPath());
-        $this->assertInternalType('array', $errors['[foo]']->getErrors());
-        $this->assertInternalType('string', $errors['[foo]']->getErrors()[0]);
+        $this->assertInstanceOf(UserDataError::class, $errors['foo']);
+        $this->assertEquals('foo', $errors['foo']->getPropertyPath());
+        $this->assertInternalType('array', $errors['foo']->getErrors());
+        $this->assertInternalType('string', $errors['foo']->getErrors()[0]);
     }
 
     public function testManyErrorForOneFormField()
@@ -84,7 +84,7 @@ class FormErrorResponseTest extends TestCase
         $formErrorResponse = new FormErrorResponse($form);
         $errors = $formErrorResponse->getErrors();
 
-        $this->assertCount(2, $errors['[foo]']->getErrors());
+        $this->assertCount(2, $errors['foo']->getErrors());
     }
 
     public function testNestedFormErrors()
@@ -99,8 +99,8 @@ class FormErrorResponseTest extends TestCase
 
         $formErrorResponse = new FormErrorResponse($form);
         $errors = $formErrorResponse->getErrors();
-        $this->assertCount(1, $errors['[foo]']->getErrors());
-        $this->assertCount(1, $errors['[bar][baz]']->getErrors());
+        $this->assertCount(1, $errors['foo']->getErrors());
+        $this->assertCount(1, $errors['bar.baz']->getErrors());
     }
 
     public function testCollectionFormErrors()
@@ -121,8 +121,9 @@ class FormErrorResponseTest extends TestCase
 
         $formErrorResponse = new FormErrorResponse($form);
         $errors = $formErrorResponse->getErrors();
-        $this->assertCount(1, $errors['[foo][0]']->getErrors());
-        $this->assertCount(1, $errors['[foo][1]']->getErrors());
+
+        $this->assertCount(1, $errors['foo[0]']->getErrors());
+        $this->assertCount(1, $errors['foo[1]']->getErrors());
     }
 
     public function testItReturnRightPropertyPathForFormWithObject()


### PR DESCRIPTION
Problem: the FormErrorResponse was returning simple form type as a PHP array. Which is on a javascript view, wrong.

Solution: transform everything which is not number indexed to an object.

Fix #53 