### PR TITLE
Improve input management

### DIFF
--- a/src/Crud/Controller/BaseCrudController.php
+++ b/src/Crud/Controller/BaseCrudController.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Biig\Melodiia\Crud\Controller;
+
+use Biig\Melodiia\Bridge\Symfony\Response\FormErrorResponse;
+use Biig\Melodiia\Crud\CrudControllerInterface;
+use Biig\Melodiia\Response\ApiResponse;
+use Biig\Melodiia\Response\WrongDataInput;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Zend\Json\Exception\RuntimeException;
+use Zend\Json\Json;
+
+abstract class BaseCrudController implements CrudControllerInterface
+{
+    /**
+     * @return ApiResponse|FormInterface
+     */
+    protected function decodeInputData(FormFactoryInterface $formFactory, string $form, Request $request, bool $clearMissing = null)
+    {
+        if (null === $clearMissing) {
+            $clearMissing = !in_array($request->getMethod(), ['POST', 'PUT']);
+        }
+        try {
+            $form = $formFactory->createNamed('', $form);
+            $inputData = Json::decode($request->getContent(), Json::TYPE_ARRAY);
+            $form->submit($inputData, $clearMissing);
+
+            if (!$form->isSubmitted()) {
+                return new WrongDataInput();
+            }
+
+            if (!$form->isValid()) {
+                return new FormErrorResponse($form);
+            }
+        } catch (RuntimeException $e) {
+            return new WrongDataInput();
+        }
+
+        return $form;
+    }
+}

--- a/src/Crud/Controller/Create.php
+++ b/src/Crud/Controller/Create.php
@@ -21,7 +21,7 @@ use Zend\Json\Json;
 /**
  * Crud controller that create data model with the data from the request using a form.
  */
-final class Create implements CrudControllerInterface
+final class Create extends BaseCrudController
 {
     use CrudControllerTrait;
 
@@ -66,17 +66,12 @@ final class Create implements CrudControllerInterface
             throw new MelodiiaLogicException('If you use melodiia CRUD classes, you need to specify a model.');
         }
 
-        $form = $this->formFactory->createNamed('', $form);
-        $inputData = Json::decode($request->getContent(), Json::TYPE_ARRAY);
-        $form->submit($inputData, $clearMissing);
-
-        if (!$form->isSubmitted()) {
-            return new WrongDataInput();
+        $formOrResponse = $this->decodeInputData($this->formFactory, $form, $request, $clearMissing);
+        if ($formOrResponse instanceof ApiResponse) {
+            return $formOrResponse;
         }
+        $form = $formOrResponse;
 
-        if (!$form->isValid()) {
-            return new FormErrorResponse($form);
-        }
         $data = $form->getData();
         $this->dispatcher->dispatch(self::EVENT_PRE_CREATE, new CrudEvent($data));
 

--- a/tests/Melodiia/Crud/Controller/CreateTest.php
+++ b/tests/Melodiia/Crud/Controller/CreateTest.php
@@ -98,6 +98,19 @@ class CreateTest extends TestCase
         $this->assertEquals(400, $res->httpStatus());
     }
 
+    /**
+     * Issue #28
+     */
+    public function testItReturnProperlyOnWrongInput()
+    {
+        $this->request->getContent()->willReturn('{"awesome":json"}'); // Wrong JSON
+
+        /** @var ApiResponse $res */
+        $res = ($this->controller)($this->request->reveal(), 'id');
+        $this->assertInstanceOf(ApiResponse::class, $res);
+        $this->assertEquals(400, $res->httpStatus());
+    }
+
     public function testItCreateMelodiiaObject()
     {
         $this->form->isSubmitted()->willReturn(true);


### PR DESCRIPTION
Problem: depending on the JSON input, sometimes the CRUD controllers were returning 500 error while the actual correct code is 400.

Solution: catch the decoding exception.

This commit also improvove the management of the form creation by using a new controller. This controller defines a protected method, if you extends a melodiia controller you will be able to change the way it behave on creation/update.

Fix #54 and #28