### PR TITLE
Removing flush a special entity

### DIFF
--- a/src/Bridge/Doctrine/DoctrineDataStore.php
+++ b/src/Bridge/Doctrine/DoctrineDataStore.php
@@ -23,7 +23,7 @@ class DoctrineDataStore implements DataStoreInterface
     public function save(object $model)
     {
         $this->getEntityManager()->persist($model);
-        $this->getEntityManager()->flush($model);
+        $this->getEntityManager()->flush();
     }
 
     public function find(string $type, $id): ?object


### PR DESCRIPTION
This feature does not work as expected and is to be removed in Doctrine 3.

Notice: API P does absolutely the same: https://github.com/api-platform/core/blob/cb22149a870763ad1abeb09b85ec4279bfe6c371/src/Bridge/Doctrine/EventListener/WriteListener.php#L69