### PR TITLE
Fix update controller - Avoid create new entity

### DIFF
--- a/src/Crud/Controller/BaseCrudController.php
+++ b/src/Crud/Controller/BaseCrudController.php
@@ -27,13 +27,13 @@ abstract class BaseCrudController implements CrudControllerInterface
     /**
      * @return ApiResponse|FormInterface
      */
-    protected function decodeInputData(FormFactoryInterface $formFactory, string $form, Request $request, bool $clearMissing = null)
+    protected function decodeInputData(FormFactoryInterface $formFactory, string $form, Request $request, bool $clearMissing = null, object $data = null)
     {
         if (null === $clearMissing) {
             $clearMissing = !in_array($request->getMethod(), ['POST', 'PUT']);
         }
         try {
-            $form = $formFactory->createNamed('', $form);
+            $form = $formFactory->createNamed('', $form, $data);
             $inputData = Json::decode($request->getContent(), Json::TYPE_ARRAY);
             $form->submit($inputData, $clearMissing);
 

--- a/src/Crud/Controller/Create.php
+++ b/src/Crud/Controller/Create.php
@@ -2,21 +2,17 @@
 
 namespace Biig\Melodiia\Crud\Controller;
 
-use Biig\Melodiia\Bridge\Symfony\Response\FormErrorResponse;
-use Biig\Melodiia\Crud\CrudControllerInterface;
 use Biig\Melodiia\Crud\Event\CrudEvent;
 use Biig\Melodiia\Crud\Event\CustomResponseEvent;
 use Biig\Melodiia\Crud\Persistence\DataStoreInterface;
 use Biig\Melodiia\Exception\MelodiiaLogicException;
 use Biig\Melodiia\Response\ApiResponse;
 use Biig\Melodiia\Response\Created;
-use Biig\Melodiia\Response\WrongDataInput;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
-use Zend\Json\Json;
 
 /**
  * Crud controller that create data model with the data from the request using a form.

--- a/src/Crud/Controller/Update.php
+++ b/src/Crud/Controller/Update.php
@@ -8,7 +8,6 @@ use Biig\Melodiia\Crud\Persistence\DataStoreInterface;
 use Biig\Melodiia\Exception\MelodiiaLogicException;
 use Biig\Melodiia\Response\ApiResponse;
 use Biig\Melodiia\Response\OkContent;
-use Biig\Melodiia\Response\WrongDataInput;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -61,7 +60,7 @@ final class Update extends BaseCrudController
             throw new MelodiiaLogicException('If you use melodiia CRUD classes, you need to specify a model.');
         }
 
-        $formOrResponse = $this->decodeInputData($this->formFactory, $form, $request, $clearMissing);
+        $formOrResponse = $this->decodeInputData($this->formFactory, $form, $request, $clearMissing, $data);
         if ($formOrResponse instanceof ApiResponse) {
             return $formOrResponse;
         }

--- a/tests/Melodiia/Bridge/Doctrine/DoctrineDataStoreTest.php
+++ b/tests/Melodiia/Bridge/Doctrine/DoctrineDataStoreTest.php
@@ -27,7 +27,7 @@ class DoctrineDataStoreTest extends TestCase
         $obj = new \stdClass();
         $entityManager = $this->prophesize(EntityManagerInterface::class);
         $entityManager->persist($obj)->shouldBeCalled();
-        $entityManager->flush($obj)->shouldBeCalled();
+        $entityManager->flush()->shouldBeCalled();
         $managerRegistry = $this->prophesize(ManagerRegistry::class);
         $managerRegistry->getManager()->willReturn($entityManager->reveal());
 


### PR DESCRIPTION
Before that the Update controller always create a new entity, without editing the current one.

Fix: Pass the data entity while creating the form instance with the formFactory