### PR TITLE
Add new concept of id resolver

### DIFF
--- a/src/Crud/Controller/Get.php
+++ b/src/Crud/Controller/Get.php
@@ -4,10 +4,14 @@ namespace Biig\Melodiia\Crud\Controller;
 
 use Biig\Melodiia\Crud\CrudControllerInterface;
 use Biig\Melodiia\Crud\Persistence\DataStoreInterface;
+use Biig\Melodiia\Crud\Tools\IdResolverInterface;
+use Biig\Melodiia\Crud\Tools\SimpleIdResolver;
+use Biig\Melodiia\Exception\IdMissingException;
 use Biig\Melodiia\Response\ApiResponse;
 use Biig\Melodiia\Response\NotFound;
 use Biig\Melodiia\Response\OkContent;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
@@ -21,17 +25,26 @@ final class Get implements CrudControllerInterface
     /** @var AuthorizationCheckerInterface */
     private $checker;
 
-    public function __construct(DataStoreInterface $dataStore, AuthorizationCheckerInterface $checker)
+    /** @var IdResolverInterface */
+    private $idResolver;
+
+    public function __construct(DataStoreInterface $dataStore, AuthorizationCheckerInterface $checker, IdResolverInterface $idResolver = null)
     {
         $this->dataStore = $dataStore;
         $this->checker = $checker;
+        $this->idResolver = $idResolver ?? new SimpleIdResolver();
     }
 
-    public function __invoke(Request $request, $id): ApiResponse
+    public function __invoke(Request $request): ApiResponse
     {
         $modelClass = $request->attributes->get(self::MODEL_ATTRIBUTE);
         $groups = $request->attributes->get(self::SERIALIZATION_GROUP, []);
         $securityCheck = $request->attributes->get(self::SECURITY_CHECK, null);
+        try {
+            $id = $this->idResolver->resolveId($request, $modelClass);
+        } catch (IdMissingException $e) {
+            throw new NotFoundHttpException('No id found', $e);
+        }
 
         $this->assertModelClassInvalid($modelClass);
 

--- a/src/Crud/Tools/IdResolverInterface.php
+++ b/src/Crud/Tools/IdResolverInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Biig\Melodiia\Crud\Tools;
+
+
+use Symfony\Component\HttpFoundation\Request;
+
+interface IdResolverInterface
+{
+    public function resolveId(Request $request, string $melodiiaModel): string;
+}

--- a/src/Crud/Tools/SimpleIdResolver.php
+++ b/src/Crud/Tools/SimpleIdResolver.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Biig\Melodiia\Crud\Tools;
+
+use Biig\Melodiia\Exception\IdMissingException;
+use Symfony\Component\HttpFoundation\Request;
+
+class SimpleIdResolver implements IdResolverInterface
+{
+    public function resolveId(Request $request, string $melodiiaModel): string
+    {
+        if ($request->attributes->has('id')) {
+            return $request->attributes->get('id');
+        }
+
+        $melodiiaModel = (new \ReflectionClass($melodiiaModel))->getShortName();
+
+        $modelId = \lcfirst($melodiiaModel) . 'Id';
+        if ($request->attributes->has($modelId)) {
+            return $request->attributes->get($modelId);
+        }
+
+        $idModel = 'id' . $melodiiaModel;
+        if ($request->attributes->has($idModel)) {
+            return $request->attributes->get($idModel);
+        }
+
+        throw new IdMissingException('Cannot find id in given request. Please provide a custom id resolver to this crud action.');
+    }
+}

--- a/src/Exception/IdMissingException.php
+++ b/src/Exception/IdMissingException.php
@@ -1,0 +1,9 @@
+<?php
+
+
+namespace Biig\Melodiia\Exception;
+
+
+class IdMissingException extends MelodiiaLogicException
+{
+}

--- a/tests/Melodiia/Bridge/Doctrine/DoctrineDataStoreTest.php
+++ b/tests/Melodiia/Bridge/Doctrine/DoctrineDataStoreTest.php
@@ -58,7 +58,7 @@ class DoctrineDataStoreTest extends TestCase
         $obj = new \stdClass();
         $entityManager = $this->prophesize(EntityManagerInterface::class);
         $entityManager->remove($obj)->shouldBeCalled();
-        $entityManager->flush($obj)->shouldBeCalled();
+        $entityManager->flush()->shouldBeCalled();
         $managerRegistry = $this->prophesize(ManagerRegistry::class);
         $managerRegistry->getManager()->willReturn($entityManager->reveal());
 

--- a/tests/Melodiia/Crud/Controller/GetTest.php
+++ b/tests/Melodiia/Crud/Controller/GetTest.php
@@ -5,6 +5,7 @@ namespace Biig\Melodiia\Test\Crud\Controller;
 use Biig\Melodiia\Crud\Controller\Get;
 use Biig\Melodiia\Crud\CrudControllerInterface;
 use Biig\Melodiia\Crud\Persistence\DataStoreInterface;
+use Biig\Melodiia\Crud\Tools\IdResolverInterface;
 use Biig\Melodiia\Response\NotFound;
 use Biig\Melodiia\Response\OkContent;
 use Biig\Melodiia\Test\TestFixtures\FakeMelodiiaModel;
@@ -30,7 +31,11 @@ class GetTest extends TestCase
     {
         $this->dataStore = $this->prophesize(DataStoreInterface::class);
         $this->authorizationChecker = $this->prophesize(AuthorizationCheckerInterface::class);
-        $this->controller = new Get($this->dataStore->reveal(), $this->authorizationChecker->reveal());
+
+        $idResolver = $this->prophesize(IdResolverInterface::class);
+        $idResolver->resolveId(Argument::type(Request::class), Argument::type('string'))->willReturn('id');
+
+        $this->controller = new Get($this->dataStore->reveal(), $this->authorizationChecker->reveal(), $idResolver->reveal());
     }
 
     public function testItIsIntanceOfMelodiiaController()
@@ -48,7 +53,7 @@ class GetTest extends TestCase
         $attributes->get(CrudControllerInterface::SECURITY_CHECK, null)->willReturn(null);
         $request->attributes = $attributes->reveal();
 
-        $res = ($this->controller)($request->reveal(), 'id');
+        $res = ($this->controller)($request->reveal());
 
         $this->assertInstanceOf(OkContent::class, $res);
         $this->assertInstanceOf(\stdClass::class, $res->getContent());
@@ -64,7 +69,7 @@ class GetTest extends TestCase
         $attributes->get(CrudControllerInterface::SECURITY_CHECK, null)->willReturn(null);
         $request->attributes = $attributes->reveal();
 
-        $res = ($this->controller)($request->reveal(), 'id');
+        $res = ($this->controller)($request->reveal());
 
         $this->assertInstanceOf(NotFound::class, $res);
     }
@@ -84,7 +89,7 @@ class GetTest extends TestCase
 
         $this->authorizationChecker->isGranted('view', Argument::any())->willReturn(false);
 
-        ($this->controller)($request->reveal(), 'id');
+        ($this->controller)($request->reveal());
     }
 
     public function testItCheckAccessAndSuccessIfAuthorized()
@@ -99,7 +104,7 @@ class GetTest extends TestCase
 
         $this->authorizationChecker->isGranted('view', Argument::any())->willReturn(true);
 
-        $res = ($this->controller)($request->reveal(), 'id');
+        $res = ($this->controller)($request->reveal());
 
         $this->assertInstanceOf(OkContent::class, $res);
         $this->assertInstanceOf(\stdClass::class, $res->getContent());

--- a/tests/Melodiia/Crud/Controller/UpdateTest.php
+++ b/tests/Melodiia/Crud/Controller/UpdateTest.php
@@ -8,6 +8,7 @@ use Biig\Melodiia\Crud\CrudControllerInterface;
 use Biig\Melodiia\Crud\Event\CrudEvent;
 use Biig\Melodiia\Crud\Event\CustomResponseEvent;
 use Biig\Melodiia\Crud\Persistence\DataStoreInterface;
+use Biig\Melodiia\Crud\Tools\IdResolverInterface;
 use Biig\Melodiia\Response\ApiResponse;
 use Biig\Melodiia\Response\OkContent;
 use Biig\Melodiia\Test\MockDispatcherTrait;
@@ -73,11 +74,16 @@ class UpdateTest extends TestCase
 
         $this->dataStore->find(FakeMelodiiaModel::class, 'id')->willReturn(new \stdClass());
 
+
+        $idResolver = $this->prophesize(IdResolverInterface::class);
+        $idResolver->resolveId(Argument::type(Request::class), Argument::type('string'))->willReturn('id');
+
         $this->controller = new Update(
             $this->dataStore->reveal(),
             $this->formFactory->reveal(),
             $this->dispatcher->reveal(),
-            $this->checker->reveal()
+            $this->checker->reveal(),
+            $idResolver->reveal()
         );
     }
 
@@ -86,7 +92,7 @@ class UpdateTest extends TestCase
         $this->form->isSubmitted()->willReturn(false);
 
         /** @var ApiResponse $res */
-        $res = ($this->controller)($this->request->reveal(), 'id');
+        $res = ($this->controller)($this->request->reveal());
 
         $this->assertInstanceOf(ApiResponse::class, $res);
         $this->assertEquals(400, $res->httpStatus());
@@ -109,7 +115,7 @@ class UpdateTest extends TestCase
         $this->request->getMethod()->willReturn('PATCH');
 
         /** @var ApiResponse $res */
-        $res = ($this->controller)($this->request->reveal(), 'id');
+        $res = ($this->controller)($this->request->reveal());
 
         $this->assertInstanceOf(ApiResponse::class, $res);
         $this->assertEquals(200, $res->httpStatus());
@@ -128,7 +134,7 @@ class UpdateTest extends TestCase
         $this->form->submit(['awesome' => 'json'], true)->willReturn()->shouldBeCalled();
 
         /** @var ApiResponse $res */
-        $res = ($this->controller)($this->request->reveal(), 'id');
+        $res = ($this->controller)($this->request->reveal());
         $this->assertInstanceOf(ApiResponse::class, $res);
         $this->assertEquals(200, $res->httpStatus());
     }
@@ -141,7 +147,7 @@ class UpdateTest extends TestCase
         $this->request->getContent()->willReturn('{"awesome":json"}'); // Wrong JSON
 
         /** @var ApiResponse $res */
-        $res = ($this->controller)($this->request->reveal(), 'id');
+        $res = ($this->controller)($this->request->reveal());
         $this->assertInstanceOf(ApiResponse::class, $res);
         $this->assertEquals(400, $res->httpStatus());
     }
@@ -152,7 +158,7 @@ class UpdateTest extends TestCase
         $this->form->isValid()->willReturn(false);
 
         /** @var ApiResponse $res */
-        $res = ($this->controller)($this->request->reveal(), 'id');
+        $res = ($this->controller)($this->request->reveal());
 
         $this->assertInstanceOf(FormErrorResponse::class, $res);
         $this->assertEquals(400, $res->httpStatus());
@@ -169,7 +175,7 @@ class UpdateTest extends TestCase
         $this->dataStore->save(Argument::type(FakeMelodiiaModel::class))->shouldBeCalled();
 
         /** @var ApiResponse $res */
-        $res = ($this->controller)($this->request->reveal(), 'id');
+        $res = ($this->controller)($this->request->reveal());
 
         $this->assertInstanceOf(OkContent::class, $res);
     }
@@ -187,7 +193,7 @@ class UpdateTest extends TestCase
         $this->dataStore->save(Argument::type(FakeMelodiiaModel::class))->shouldBeCalled();
 
         /** @var ApiResponse $res */
-        $res = ($this->controller)($this->request->reveal(), 'id');
+        $res = ($this->controller)($this->request->reveal());
 
         $this->assertInstanceOf(OkContent::class, $res);
     }
@@ -200,6 +206,6 @@ class UpdateTest extends TestCase
         $this->attributes->get(CrudControllerInterface::SECURITY_CHECK, null)->willReturn('edit');
         $this->checker->isGranted(Argument::cetera())->willReturn(false);
 
-        ($this->controller)($this->request->reveal(), 'id');
+        ($this->controller)($this->request->reveal());
     }
 }

--- a/tests/Melodiia/Crud/Tools/SimpleIdResolverTest.php
+++ b/tests/Melodiia/Crud/Tools/SimpleIdResolverTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Biig\Melodiia\Test\Crud\Tools;
+
+use Biig\Melodiia\Crud\Tools\IdResolverInterface;
+use Biig\Melodiia\Crud\Tools\SimpleIdResolver;
+use Biig\Melodiia\Exception\IdMissingException;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\ParameterBag;
+use Symfony\Component\HttpFoundation\Request;
+
+class SimpleIdResolverTest extends TestCase
+{
+    private $subject;
+
+    protected function setUp()
+    {
+        $this->subject = new SimpleIdResolver();
+    }
+
+    protected function tearDown()
+    {
+        $this->subject = null;
+    }
+
+    public function testItIsInstanceOfIdResolverInterface()
+    {
+        $this->assertInstanceOf(IdResolverInterface::class, $this->subject);
+    }
+
+    public function testItGetsStandardIdIfAvailable()
+    {
+        $request = $this->getRequest(['id' => 'foo']);
+
+        $this->assertEquals('foo', $this->subject->resolveId($request, SimpleIdFakeModel::class));
+    }
+
+    public function testItGetsSpecificToModelId()
+    {
+        $request = $this->getRequest(['simpleIdFakeModelId' => 'yolo']);
+
+        $this->assertEquals('yolo', $this->subject->resolveId($request, SimpleIdFakeModel::class));
+    }
+
+    public function testItThrowsIfImpossibleToFindId()
+    {
+        $this->expectException(IdMissingException::class);
+        $this->subject->resolveId($this->getRequest([]), SimpleIdFakeModel::class);
+    }
+
+    private function getRequest(array $attributes): Request
+    {
+        $request = $this->prophesize(Request::class);
+        $request->attributes = new ParameterBag($attributes);
+
+        return $request->reveal();
+    }
+}
+
+class SimpleIdFakeModel
+{
+}


### PR DESCRIPTION
Problem:
Our controller had hardcoded id getter in the request, but it's actually
quite normal to have the ability of changing this id name inside the
route.

Solution:
After thinking first to make controller not final with a protected
method inside, I finally did this implementation of an id resolver. It
could even be configurable in the future with a new configurable class
id resolver.

This is a fix for #64