### PR TITLE
Fix #36 by adding a CollectionType

### DIFF
--- a/src/Bridge/Symfony/Form/Listener/ReorderDataToMatchCollectionListener.php
+++ b/src/Bridge/Symfony/Form/Listener/ReorderDataToMatchCollectionListener.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Biig\Melodiia\Bridge\Symfony\Form\Listener;
+
+use Biig\Melodiia\Crud\CrudableModelInterface;
+use Biig\Melodiia\Exception\MelodiiaLogicException;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Form\Event\PreSubmitEvent;
+use Symfony\Component\Form\FormEvents;
+
+class ReorderDataToMatchCollectionListener implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents()
+    {
+        return [
+            // (PRE SUBMIT of ResizeFormListener must comes after)
+            FormEvents::PRE_SUBMIT => ['preSubmit', 10],
+        ];
+    }
+
+    public function preSubmit(PreSubmitEvent $event)
+    {
+        $data = $event->getData();
+        if (empty($data)) {
+            return;
+        }
+
+        $form = $event->getForm();
+        $dataOrdered = [];
+
+        // We need to know the last index of the collection.
+        // We cannot do incremental index for data because the last index may be deleted.
+        $lastCollectionIndex = 0;
+        foreach ($form as $name => $child) {
+            $lastCollectionIndex = $name;
+            $item = $child->getData();
+            if (!$item instanceof CrudableModelInterface) {
+                throw new MelodiiaLogicException(sprintf(
+                    'Impossible manage the model of type "%s" inside Melodiia because it does not implement CrudableModelInterface.',
+                    get_class($item)
+                ));
+            }
+            $itemId = (string) $item->getId();
+            foreach ($data as $inputItem) {
+                if (!isset($inputItem['id'])) {
+                    continue;
+                }
+                if ($inputItem['id'] === $itemId) {
+                    $dataOrdered[$name] = $inputItem;
+                    break; // This break removes duplicated items (based on id) inside input data
+                }
+            }
+        }
+
+        // Add "new" items (without id) to the data ordered
+        foreach ($data as $inputItem) {
+            if (!isset($inputItem['id'])) {
+                $lastCollectionIndex++;
+                $dataOrdered[$lastCollectionIndex] = $inputItem;
+            }
+        }
+
+        // Removing ids, they are just here for this listener and are not part of the form.
+        foreach ($dataOrdered as $index => $item) {
+            if (isset($dataOrdered[$index]['id'])) {
+                unset($dataOrdered[$index]['id']);
+            }
+        }
+
+        $event->setData($dataOrdered);
+    }
+}

--- a/src/Bridge/Symfony/Form/Type/MelodiiaCollectionType.php
+++ b/src/Bridge/Symfony/Form/Type/MelodiiaCollectionType.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Biig\Melodiia\Bridge\Symfony\Form\Type;
+
+use Biig\Melodiia\Bridge\Symfony\Form\Listener\ReorderDataToMatchCollectionListener;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\EventListener\ResizeFormListener;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class MelodiiaCollectionType extends AbstractType
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $resizeListener = new ResizeFormListener(
+            $options['entry_type'],
+            $options['entry_options'],
+            $options['allow_add'],
+            $options['allow_delete'],
+            $options['delete_empty']
+        );
+
+        $reorderInputDataListener = new ReorderDataToMatchCollectionListener();
+
+        $builder->addEventSubscriber($resizeListener);
+        $builder->addEventSubscriber($reorderInputDataListener);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildView(FormView $view, FormInterface $form, array $options)
+    {
+        $view->vars = array_replace($view->vars, [
+            'allow_add' => $options['allow_add'],
+            'allow_delete' => $options['allow_delete'],
+        ]);
+
+        if ($form->getConfig()->hasAttribute('prototype')) {
+            $prototype = $form->getConfig()->getAttribute('prototype');
+            $view->vars['prototype'] = $prototype->setParent($form)->createView($view);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'allow_add' => true,
+            'allow_delete' => true,
+            'prototype' => true,
+            'entry_type' => TextType::class,
+            'entry_options' => [],
+            'delete_empty' => false,
+        ]);
+
+        $resolver->setAllowedTypes('delete_empty', ['bool', 'callable']);
+    }
+}

--- a/tests/Melodiia/Bridge/Symfony/Form/Listener/ReorderDataToMatchCollectionListenerTest.php
+++ b/tests/Melodiia/Bridge/Symfony/Form/Listener/ReorderDataToMatchCollectionListenerTest.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace Biig\Melodiia\Test\Bridge\Symfony\Form\Listener;
+
+use Biig\Melodiia\Bridge\Symfony\Form\Listener\ReorderDataToMatchCollectionListener;
+use Biig\Melodiia\Crud\CrudableModelInterface;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Event\PreSubmitEvent;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilder;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormFactoryBuilder;
+use Symfony\Component\Form\Test\FormIntegrationTestCase;
+
+class ReorderDataToMatchCollectionListenerTest extends FormIntegrationTestCase
+{
+    private $subject;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->factory = (new FormFactoryBuilder())->getFormFactory();
+        $this->subject = new ReorderDataToMatchCollectionListener();
+    }
+
+    protected function tearDown()
+    {
+        parent::tearDown();
+        $this->factory = null;
+        $this->subject = null;
+    }
+
+    protected function getBuilder($name = 'name', $data = null)
+    {
+        $options = ['data' => $data];
+        if (!empty($data)) {
+            $options['compound'] = true;
+        }
+        return new FormBuilder($name, null, new EventDispatcher(), $this->factory, $options);
+    }
+
+    protected function getForm($name = 'name', $data = null)
+    {
+        $builder = $this->getBuilder($name, $data);
+        foreach ($data as $name => $item) {
+            $form = $this->getBuilder($name, $item)
+                ->add(0, TextType::class)
+                ->add(1, TextType::class)
+                ->getForm()
+            ;
+            $builder->add($name, $form);
+        }
+        return $builder->getForm();
+    }
+
+    public function testItReorderDataInputWithFormData()
+    {
+        $formData = [
+            new class extends \ArrayObject implements CrudableModelInterface {
+                public function __construct()
+                {
+                    parent::__construct(['hello' => 'yo', 'world' => 'ye']);
+                }
+
+                public $hello = 'yo';
+                public $world = 'ye';
+                public function getId()
+                {
+                    return 'foo';
+                }
+            },
+            new class extends \ArrayObject  implements CrudableModelInterface {
+                public function __construct()
+                {
+                    parent::__construct(['hello' => 'yoh', 'world' => 'yeh']);
+                }
+                public $hello = 'yoh';
+                public $world = 'yeh';
+                public function getId()
+                {
+                    return 'bar';
+                }
+            }
+        ];
+        $form = $this->factory->createNamed('', FormType::class, $formData)
+            ->add(0, HelloWorldDummyType::class)
+            ->add(1, HelloWorldDummyType::class)
+        ;
+        $data = [['hello' => 'baz'], ['id' => 'bar', 'hello' => 'bar'], ['id' => 'foo', 'hello' => 'foo']];
+        $event = new PreSubmitEvent($form, $data);
+        $this->subject->preSubmit($event);
+
+        // The listener will remove ids
+        // it will order known items and add new at the end
+        $this->assertEquals(
+            [['hello' => 'foo'], ['hello' => 'bar'],['hello' => 'baz']],
+            $event->getData()
+        );
+    }
+
+    public function testItRemovesDataThatDoesNotExistsAnymore()
+    {
+        $formData = [
+            new class extends \ArrayObject implements CrudableModelInterface {
+                public function __construct()
+                {
+                    parent::__construct(['hello' => 'yo', 'world' => 'ye']);
+                }
+
+                public $hello = 'yo';
+                public $world = 'ye';
+                public function getId()
+                {
+                    return 'foo';
+                }
+            },
+        ];
+        $form = $this->factory->createNamed('', FormType::class, $formData)
+            ->add(0, HelloWorldDummyType::class)
+        ;
+        $data = [['hello' => 'bar']];
+        $event = new PreSubmitEvent($form, $data);
+        $this->subject->preSubmit($event);
+
+        // Will remove known foo (indexed by 0) and add new bar
+        $this->assertEquals(
+            [1 => ['hello' => 'bar']],
+            $event->getData()
+        );
+    }
+
+    public function testItDoesNothingOnEmptyData()
+    {
+        $event = $this->prophesize(PreSubmitEvent::class);
+        $event->getData()->willReturn(null);
+        $event->getForm()->shouldNotBeCalled();
+        $this->subject->preSubmit($event->reveal());
+    }
+}
+
+class HelloWorldDummyType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder->add('hello')->add('world');
+    }
+}


### PR DESCRIPTION
Problem:
The Symfony CollectionType is cool in the context of Forms. But when it
comes to API new problems comes:
1. Data order (because the order of data input is not predictable)
2. Id management (because we need ids to re-order, but they are not in
   the form type
3. We do not need all the front-end related stuff tha the Sf collection
   supports

Solution:
Adding a custom CollectionType dedicated to Melodiia usages.