### PR TITLE
This melodiia version is outdated and should not be used as reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ Melodiia
 
 Finally some competitor to ApiPlatform.
 
+Important warning: biig-io/melodiia is no more maintained. You should checkout the fork at [SwagIndustries](https://github.com/swagindustries/Melodiia).
+You also may be interested by the [new documentation](https://melodiia.swag.industries/).
+
 Features
 --------
 


### PR DESCRIPTION
I build Melodiia at my nights while I was using it at day working at BiiG.

After leaving the company [I tried to continue](https://github.com/biig-io/Melodiia/pulls?q=is%3Apr+sort%3Aupdated-desc+is%3Aclosed) to help to maintain the library because I use it as well on other projects. But finally, nothing happened here. I finally decided to fork it.

To avoid people to think this project is the main one, I open this PR just to have a forward to the correct project, mostly because the code and the documentation are really outdated.